### PR TITLE
Rename `queue` command to `quo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamgee",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A Discord bot for managing a song request queue.",
   "private": true,
   "scripts": {

--- a/src/commands/__mocks__/index.ts
+++ b/src/commands/__mocks__/index.ts
@@ -33,8 +33,8 @@ allCommands.set("ping", {
   name: "ping",
   execute: jest.fn().mockResolvedValue(undefined)
 });
-allCommands.set("queue", {
-  name: "queue",
+allCommands.set("quo", {
+  name: "quo",
   execute: jest.fn().mockResolvedValue(undefined)
 });
 allCommands.set("sr", {

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -25,16 +25,16 @@ exports[`Help command describes all commands 1`] = `
 \`?limits\` - Display the song queue's submission limits.
 \`?now-playing\` - Reveal the current song in the queue (or my best guess).
 \`?ping\` - Ping my host server to check latency.
-\`?queue\` - Administrative commands to manage the song queue.
-    \`?queue setup [channel]\` - Set a channel as the 'queue' channel.
-    \`?queue teardown\` - Deletes and un-sets the current queue.
-    \`?queue blacklist [?user]\` - Show the list of blacklisted users, or add a user to the blacklist.
-    \`?queue whitelist [user]\` - Allows a previously-blacklisted user to make song requests.
-    \`?queue open\` - Start accepting song requests to the queue.
-    \`?queue close\` - Stop accepting song requests to the queue.
-    \`?queue limit <entry-duration | cooldown | count> [?value]\` - Set a limit value on the queue. (Time in seconds, where applicable)
-    \`?queue stats\` - Print statistics on the current queue.
-    \`?queue restart\` - Empty the queue and start a fresh queue session.
+\`?quo\` - Administrative commands to manage the song queue.
+    \`?quo setup [channel]\` - Set a channel as the 'queue' channel.
+    \`?quo teardown\` - Deletes and un-sets the current queue.
+    \`?quo blacklist [?user]\` - Show the list of blacklisted users, or add a user to the blacklist.
+    \`?quo whitelist [user]\` - Allows a previously-blacklisted user to make song requests.
+    \`?quo open\` - Start accepting song requests to the queue.
+    \`?quo close\` - Stop accepting song requests to the queue.
+    \`?quo limit <entry-duration | cooldown | count> [?value]\` - Set a limit value on the queue. (Time in seconds, where applicable)
+    \`?quo stats\` - Print statistics on the current queue.
+    \`?quo restart\` - Empty the queue and start a fresh queue session.
 \`?sr [?url]\` - Submit a song to the queue.
 \`?t\` - Start a typing indicator.
 \`?version\` - Display the bot's current codebase version.

--- a/src/commands/queue/index.ts
+++ b/src/commands/queue/index.ts
@@ -33,14 +33,15 @@ const sr: Command = {
   permissions: ["owner", "admin", "queue-admin"],
   async execute(context) {
     if (!isNonEmptyArray(context.options)) {
-      const response = new StringBuilder("The possible subcommands are:");
-      Object.values(namedSubcommands).forEach(command => {
-        response.pushNewLine();
-        response.push(" - ");
-        response.pushCode(command.name);
-      });
+      // const response = new StringBuilder("The possible subcommands are:");
+      // Object.values(namedSubcommands).forEach(command => {
+      //   response.pushNewLine();
+      //   response.push(" - ");
+      //   response.pushCode(command.name);
+      // });
 
-      return context.reply(response.result());
+      // return context.reply(response.result());
+      return; // do nothing
     }
 
     const arg: string = resolveSubcommandNameFromOption(context.options[0]);

--- a/src/commands/queue/index.ts
+++ b/src/commands/queue/index.ts
@@ -26,22 +26,21 @@ const namedSubcommands = [
 ];
 
 const sr: Command = {
-  name: "queue",
+  name: "sradmin",
   description: "Administrative commands to manage the song queue.",
   options: namedSubcommands,
   requiresGuild: true,
   permissions: ["owner", "admin", "queue-admin"],
   async execute(context) {
     if (!isNonEmptyArray(context.options)) {
-      // const response = new StringBuilder("The possible subcommands are:");
-      // Object.values(namedSubcommands).forEach(command => {
-      //   response.pushNewLine();
-      //   response.push(" - ");
-      //   response.pushCode(command.name);
-      // });
+      const response = new StringBuilder("The possible subcommands are:");
+      Object.values(namedSubcommands).forEach(command => {
+        response.pushNewLine();
+        response.push(" - ");
+        response.pushCode(command.name);
+      });
 
-      // return context.reply(response.result());
-      return; // do nothing
+      return context.reply(response.result());
     }
 
     const arg: string = resolveSubcommandNameFromOption(context.options[0]);

--- a/src/commands/queue/index.ts
+++ b/src/commands/queue/index.ts
@@ -26,7 +26,7 @@ const namedSubcommands = [
 ];
 
 const sr: Command = {
-  name: "sradmin",
+  name: "qu",
   description: "Administrative commands to manage the song queue.",
   options: namedSubcommands,
   requiresGuild: true,

--- a/src/commands/queue/index.ts
+++ b/src/commands/queue/index.ts
@@ -26,7 +26,7 @@ const namedSubcommands = [
 ];
 
 const sr: Command = {
-  name: "qu",
+  name: "quo",
   description: "Administrative commands to manage the song queue.",
   options: namedSubcommands,
   requiresGuild: true,

--- a/src/handleCommand.test.ts
+++ b/src/handleCommand.test.ts
@@ -161,7 +161,7 @@ describe("Command handler", () => {
       ${"limits"}
       ${"now-playing"}
       ${"ping"}
-      ${"queue"}
+      ${"quo"}
       ${"sr"}
       ${"t"}
       ${"version"}
@@ -192,7 +192,7 @@ describe("Command handler", () => {
       ${"limits"}
       ${"now-playing"}
       ${"ping"}
-      ${"queue"}
+      ${"quo"}
       ${"sr"}
       ${"t"}
       ${"version"}

--- a/tests/commandsAsAdmin.test.ts
+++ b/tests/commandsAsAdmin.test.ts
@@ -12,7 +12,7 @@ const UUT_ID = requireEnv("BOT_TEST_ID");
 const RUN_CHANNEL_ID = requireEnv("CHANNEL_ID");
 const QUEUE_CHANNEL_ID = requireEnv("QUEUE_CHANNEL_ID");
 
-const QUEUE_COMMAND = "queue";
+const QUEUE_COMMAND = "quo";
 
 describe("Command as admin", () => {
   const url = "https://youtu.be/dQw4w9WgXcQ";

--- a/tests/commandsAsPleb.test.ts
+++ b/tests/commandsAsPleb.test.ts
@@ -8,7 +8,7 @@ import {
 
 const QUEUE_CHANNEL_ID = requireEnv("QUEUE_CHANNEL_ID");
 
-const QUEUE_COMMAND = "queue";
+const QUEUE_COMMAND = "quo";
 
 describe("Command as pleb", () => {
   const url = "https://youtu.be/dQw4w9WgXcQ";


### PR DESCRIPTION
This is a temporary fix. The server that uses Gamgee most has another bot that uses `?queue`. While I'm working on a more expandable solution for command aliasing, I've renamed `?queue` to `?quo` for now.