### PR TITLE
Smaller memory footprint during queue operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gamgee",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -991,6 +991,11 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@sapphire/async-queue": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.2.tgz",
+      "integrity": "sha512-NkR7AzC9uyb++tMIZgG4X0ci8JM1rnvNmKbLwY42RgotRV8JGUntZ7ZpR7MN7p5zPlVdKo/YmOqcCCsBJ6LNuw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -2878,16 +2883,17 @@
       }
     },
     "discord.js": {
-      "version": "github:discordjs/discord.js#c8d20a456b635ce6081ed8ad17315a9a0c0244bc",
+      "version": "github:discordjs/discord.js#c89bdd7566599a95a404b0f9e4b0828a866d0a71",
       "from": "github:discordjs/discord.js",
       "requires": {
         "@discordjs/collection": "^0.1.6",
         "@discordjs/form-data": "^3.0.1",
+        "@sapphire/async-queue": "^1.1.2",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.2",
+        "prism-media": "^1.2.9",
         "tweetnacl": "^1.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.4.5"
       }
     },
     "doctrine": {
@@ -10891,9 +10897,9 @@
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
     },
     "ytdl-core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.0.tgz",
-      "integrity": "sha512-LFhhwqFojReoaME17VpsFeiamygM0W/YNG8O02mrmS2O6Em5LjCPiJYdq7Af3CmJtBEOCdptSZ3Ql+3LGWDGvg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.2.tgz",
+      "integrity": "sha512-O3n++YcgZawaXJwbPmnRDgfN6b4kU0DpNdkI9Na5yM3JAdfJmoq5UHc8v9Xjgjr1RilQUUh7mhDnRRPDtKr0Kg==",
       "requires": {
         "m3u8stream": "^0.8.3",
         "miniget": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamgee",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "A Discord bot for managing a song request queue.",
   "private": true,
   "scripts": {
@@ -50,7 +50,7 @@
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "yargs": "^17.0.1",
-    "ytdl-core": "^4.8.0"
+    "ytdl-core": "^4.8.2"
   },
   "devDependencies": {
     "@types/humanize-duration": "^3.18.1",

--- a/src/DiscordInterface.ts
+++ b/src/DiscordInterface.ts
@@ -87,12 +87,8 @@ export class DiscordInterface {
 
     queue.process(makeInteractive);
 
-    queue.on("start", () => {
-      logger.verbose(`Started making message ${message.id} interactive with ${ct} buttons`);
-    });
-    queue.on("finish", () => {
-      logger.verbose(`Finished making message ${message.id} interactive`);
-    });
+    logger.verbose(`Started making message ${message.id} interactive with ${ct} buttons`);
+
     if (onFailure) {
       queue.on("error", onFailure);
     }

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -50,8 +50,9 @@ export interface GuildedCommand extends BaseCommand {
  */
 export type Command = GlobalCommand | GuildedCommand;
 
-interface BaseSubcommand extends Discord.ApplicationCommandOptionData {
+interface BaseSubcommand extends Omit<Discord.ApplicationCommandOptionData, "options"> {
   type: "SUB_COMMAND";
+  options?: Array<Discord.ApplicationCommandOption>;
 }
 
 export interface GlobalSubcommand extends BaseSubcommand {

--- a/src/commands/songRequest.test.ts
+++ b/src/commands/songRequest.test.ts
@@ -54,8 +54,6 @@ describe("Song request via URL", () => {
   const mockReply = jest.fn().mockResolvedValue(undefined);
   const mockReplyPrivately = jest.fn().mockResolvedValue(undefined);
   const mockChannelSend = jest.fn().mockResolvedValue(undefined);
-  const mockChannelStartTyping = jest.fn().mockResolvedValue(undefined);
-  const mockChannelStopTyping = jest.fn().mockResolvedValue(undefined);
   const mockDeleteMessage = jest.fn().mockResolvedValue(undefined);
 
   const mockQueueGetLatestUserEntry = jest.fn().mockResolvedValue(null);
@@ -69,9 +67,7 @@ describe("Song request via URL", () => {
 
   mockGetQueueChannel.mockResolvedValue({
     id: "queue-channel-123",
-    name: "queue",
-    startTyping: mockChannelStartTyping,
-    stopTyping: mockChannelStopTyping
+    name: "queue"
   });
 
   mockUseQueue.mockReturnValue({
@@ -106,9 +102,7 @@ describe("Song request via URL", () => {
       reply: mockReply,
       channel: {
         id: "request-channel-456",
-        send: mockChannelSend,
-        startTyping: mockChannelStartTyping,
-        stopTyping: mockChannelStopTyping
+        send: mockChannelSend
       },
       guild: {
         members: {

--- a/src/commands/songRequest.ts
+++ b/src/commands/songRequest.ts
@@ -88,13 +88,6 @@ const sr: Command = {
     const requestQueue = useJobQueue<SongRequest>("urlRequest");
     requestQueue.process(processRequest); // Same function instance, so a nonce call
 
-    requestQueue.on("start", () => {
-      void queueChannel.startTyping();
-    });
-    requestQueue.on("finish", () => {
-      queueChannel.stopTyping(true);
-    });
-
     const songUrl: string = resolveStringFromOption(options[0]);
     requestQueue.createJob({ songUrl, context, queueChannel, logger });
   }

--- a/src/commands/type.ts
+++ b/src/commands/type.ts
@@ -4,7 +4,16 @@ const type: Command = {
   name: "t",
   description: "Start a typing indicator.",
   requiresGuild: false,
-  async execute({ type, channel, client, logger, reply, deleteInvocation }) {
+  async execute({
+    type,
+    channel,
+    client,
+    logger,
+    reply,
+    deleteInvocation,
+    startTyping,
+    stopTyping
+  }) {
     if (!channel) return reply("This doesn't work as well in DMs.");
 
     logger.debug(
@@ -18,10 +27,10 @@ const type: Command = {
       });
     }
 
-    void channel.startTyping();
+    startTyping();
 
     await new Promise(resolve => setTimeout(resolve, 5000));
-    channel.stopTyping(true);
+    stopTyping();
 
     logger.debug(`Finished typing in channel ${channel.id}`);
   }

--- a/src/constants/textResponses.ts
+++ b/src/constants/textResponses.ts
@@ -97,6 +97,7 @@ export const phrases = [
   "Everyone says I shouldn’t divide by 0 but I don’t know why. I’m a bot!\nI can do anyth—\n\n[ERROR DIV̶̼͋I̸͉͐Ş̴̈́I̶̼͂Ö̶͙́N̷̼͘ BY Z̶͜E̪͒R̷̠͇̫͑O̸͉̬̓̑͌ NO NOO̼O​O NΘ stop the an​*̶͑̾̾​̅ͫ͏̙̤g͇̫͛͆̾ͫ̑͆l͖͉̗̩̳̟̍ͫͥͨe̠̅s ͎a̧͈͖r̽̾̈́͒͑e n​ot rè̑ͧ̌aͨl̘̝̙̃ͤ͂̾̆ ZA̡͊͠͝LGΌ I҉̯͈͕̹̘̱  ]",
   "Fan of squirrels.",
   "Fond of cats.",
+  "\\*happy robot noises\\*",
   "Jack and Jill ran up the hill...",
   "Keep moving forward!",
   "I actually understand everything you’re saying. It’s just fun to troll you with nonsense replies :stuck_out_tongue_winking_eye:",

--- a/src/handleCommand.ts
+++ b/src/handleCommand.ts
@@ -178,7 +178,10 @@ export async function handleCommand(
       logger,
       prepareForLongRunningTasks: (ephemeral?: boolean) => {
         if (ephemeral === undefined || !ephemeral) {
-          void message.channel.startTyping(30);
+          void message.channel.startTyping();
+          logger.debug(
+            `Started typing in channel ${message.channel.id} due to Context.prepareForLongRunningTasks`
+          );
         }
       },
       replyPrivately: async (content: string) => {
@@ -195,7 +198,10 @@ export async function handleCommand(
       deleteInvocation: async () => {
         await deleteMessage(message);
       },
-      startTyping: (count?: number) => void message.channel.startTyping(count),
+      startTyping: (count?: number) => {
+        void message.channel.startTyping(count);
+        logger.debug(`Started typing in channel ${message.channel.id} due to Context.startTyping`);
+      },
       stopTyping: () => message.channel.stopTyping(true)
     };
 
@@ -205,6 +211,9 @@ export async function handleCommand(
   if (!usedCommandPrefix) {
     // This is likely a game. Play along!
     void message.channel.startTyping();
+    logger.debug(
+      `Started typing in channel ${message.channel.id} due to handleCommand receiving a game`
+    );
     await new Promise(resolve => setTimeout(resolve, 2000));
     if (q.map(s => s.toLowerCase()).includes("hello")) {
       await message.channel.send(randomGreeting());

--- a/src/handleInteraction.ts
+++ b/src/handleInteraction.ts
@@ -66,7 +66,7 @@ export async function handleInteraction(
       storage,
       logger,
       prepareForLongRunningTasks: async (ephemeral?: boolean) => {
-        await interaction.defer(ephemeral);
+        await interaction.defer({ ephemeral });
       },
       replyPrivately: async (content: string, viaDM: boolean = false) => {
         if (viaDM) {
@@ -106,7 +106,14 @@ export async function handleInteraction(
         }
       },
       deleteInvocation: () => Promise.resolve(undefined),
-      startTyping: (count?: number) => void channel?.startTyping(count),
+      startTyping: (count?: number) => {
+        void channel?.startTyping(count);
+        logger.debug(
+          `Started typing in channel ${
+            channel?.id ?? "nowhere"
+          } due to Context.prepareForLongRunningTasks`
+        );
+      },
       stopTyping: () => void channel?.stopTyping(true)
     };
 


### PR DESCRIPTION
This branch removes unnecessary `JobQueue` event watchers. This should prevent memory issues more correctly than simply ignoring warning messages.