### PR TITLE
Total time cap

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -2,7 +2,7 @@ import * as _entities from "./dist/database/model/index.js";
 import * as _migrations from "./dist/database/migrations/index.js";
 
 export default {
-	type: "sqlite3",
+	type: "sqlite",
 	database: "./db/db.sqlite",
 	entities: Object.values(_entities),
 	migrations: Object.values(_migrations),

--- a/src/actions/messages/replyToMessage.ts
+++ b/src/actions/messages/replyToMessage.ts
@@ -61,10 +61,13 @@ async function sendDM(
 	}
 }
 
-function replyMessage(channel: { id: string } | null, content: string | null | undefined): string {
+function replyMessage(
+	source: Discord.TextBasedChannels | null,
+	content: string | null | undefined
+): string {
 	const msg = createPartialString();
-	if (channel) {
-		push(`(Reply from <#${channel.id}>)`, msg);
+	if (source && source.type !== "DM") {
+		push(`(Reply from <#${source.id}>)`, msg);
 		pushNewLine(msg);
 	}
 	push(content ?? "", msg);

--- a/src/actions/queue/processSongRequest.ts
+++ b/src/actions/queue/processSongRequest.ts
@@ -220,7 +220,7 @@ export async function processSongRequest(request: SongRequest): Promise<void> {
 		await acceptSongRequest({ queueChannel, context, entry, logger });
 
 		// ** If the queue would be overfull with this submission, accept the submission then close the queue
-		const totalPlaytimeLimit = config.queueDurationSeconds ?? null;
+		const totalPlaytimeLimit = config.queueDurationSeconds;
 		if (totalPlaytimeLimit !== null && playtimeTotal + seconds > totalPlaytimeLimit) {
 			const durationLimitMsg = durationString(totalPlaytimeLimit, true);
 			logger.info(`The queue's duration limit is ${durationLimitMsg}. Closing the queue.`);

--- a/src/actions/queue/useQueue.ts
+++ b/src/actions/queue/useQueue.ts
@@ -66,7 +66,7 @@ function queueMessageFromEntry(
 	};
 }
 
-/** Retrieves the playtime of the queue's unfinished entries. */
+/** Retrieves the playtime (in seconds) of the queue's unfinished entries. */
 export async function playtimeRemainingInQueue(queueChannel: Discord.TextChannel): Promise<number> {
 	const queue = await fetchAllEntries(queueChannel);
 	let duration = 0;
@@ -78,7 +78,7 @@ export async function playtimeRemainingInQueue(queueChannel: Discord.TextChannel
 	return duration;
 }
 
-/** Retrieves the total playtime of the queue's entries. */
+/** Retrieves the total playtime (in seconds) of the queue's entries. */
 export async function playtimeTotalInQueue(queueChannel: Discord.TextChannel): Promise<number> {
 	const queue = await fetchAllEntries(queueChannel);
 	let duration = 0;
@@ -88,7 +88,7 @@ export async function playtimeTotalInQueue(queueChannel: Discord.TextChannel): P
 	return duration;
 }
 
-/** Retrieves the average playtime of the queue's entries. */
+/** Retrieves the average playtime (in seconds) of the queue's entries. */
 export async function playtimeAverageInQueue(queueChannel: Discord.TextChannel): Promise<number> {
 	const queue = await fetchAllEntries(queueChannel);
 	let average = 0;

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Help command describe pleb commands 1`] = `
 "Commands:
+\`?cooldown\` - Find out when you can submit again.
 \`?help\` - Print a handy help message.
 \`?howto\` - Print instructions for using the common queue commands.
 \`?languages\` - Print my core repository's language statistics.
@@ -9,6 +10,7 @@ exports[`Help command describe pleb commands 1`] = `
 \`?now-playing\` OR \`?nowplaying\` - Reveal the current song in the queue (or my best guess).
 \`?ping\` - Ping my host server to check latency.
 \`?sr [url]\` - Submit a song to the queue.
+\`?stats\` - Get your personal queue statistics.
 \`?test\` - Make sure I still know how to talk to video services.
 \`?t\` - Start a typing indicator.
 \`?version\` - Display the bot's current codebase version.
@@ -22,6 +24,7 @@ exports[`Help command describes all commands 1`] = `
     \`?config get <command_prefix>\` - Get the value of a configuration setting.
     \`?config set <command_prefix> [value]\` - Set the value of a configuration setting.
     \`?config unset <command_prefix>\` - Reset the value of a configuration setting to default.
+\`?cooldown\` - Find out when you can submit again.
 \`?help\` - Print a handy help message.
 \`?howto\` - Print instructions for using the common queue commands.
 \`?languages\` - Print my core repository's language statistics.
@@ -35,10 +38,11 @@ exports[`Help command describes all commands 1`] = `
     \`?quo whitelist [user]\` - Allows a previously-blacklisted user to make song requests.
     \`?quo open\` - Start accepting song requests to the queue.
     \`?quo close\` - Stop accepting song requests to the queue.
-    \`?quo limit <entry-duration | cooldown | count> [?value]\` - Set a limit value on the queue. (Time in seconds, where applicable)
+    \`?quo limit <count | cooldown | entry-duration | queue-duration> [?value]\` - Set a limit value on the queue. (Time in seconds, where applicable)
     \`?quo stats\` - Print statistics on the current queue.
     \`?quo restart\` - Empty the queue and start a fresh queue session.
 \`?sr [url]\` - Submit a song to the queue.
+\`?stats\` - Get your personal queue statistics.
 \`?test\` - Make sure I still know how to talk to video services.
 \`?t\` - Start a typing indicator.
 \`?version\` - Display the bot's current codebase version.

--- a/src/commands/__snapshots__/limits.test.ts.snap
+++ b/src/commands/__snapshots__/limits.test.ts.snap
@@ -6,22 +6,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	infinite",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	none",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	infinite",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	none",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	infinite",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -43,22 +48,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	infinite",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	42 seconds",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	infinite",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	42 seconds",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	infinite",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -80,22 +90,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	42 seconds",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	none",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	infinite",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	none",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	42 seconds",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -117,22 +132,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	infinite",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	none",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	42",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	none",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	infinite",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -154,22 +174,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	42 seconds",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	42 seconds",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	infinite",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	42 seconds",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	42 seconds",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -191,22 +216,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	42 seconds",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	none",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	42",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	none",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	42 seconds",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -228,22 +258,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	infinite",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	42 seconds",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	42",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	42 seconds",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	infinite",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,
@@ -265,22 +300,27 @@ Object {
     Object {
       "author": null,
       "color": null,
-      "description": null,
+      "description": "Use \`/cooldown\` to see your cooldown time",
       "fields": Array [
-        Object {
-          "inline": false,
-          "name": "Song Length:	42 seconds",
-          "value": "The maximum duration of a song submission.",
-        },
-        Object {
-          "inline": false,
-          "name": "Submission Cooldown:	42 seconds",
-          "value": "The minimum amount of time that each user must wait between their own submissions.",
-        },
         Object {
           "inline": false,
           "name": "Number of Submissions:	42",
           "value": "The maximum number of submissions that each user may submit.",
+        },
+        Object {
+          "inline": false,
+          "name": "Submission Cooldown:	42 seconds",
+          "value": "The minimum amount of time (in seconds) that each user must wait between their own submissions.",
+        },
+        Object {
+          "inline": false,
+          "name": "Song Length:	42 seconds",
+          "value": "The maximum duration (in seconds) of a song submission.",
+        },
+        Object {
+          "inline": false,
+          "name": "Total Queue Length:	infinite",
+          "value": "The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit.",
         },
       ],
       "footer": null,

--- a/src/commands/limits.ts
+++ b/src/commands/limits.ts
@@ -1,5 +1,6 @@
 import type { Command } from "./Command.js";
 import { allLimits } from "./queue/limit.js";
+import { assertUnreachable } from "../helpers/assertUnreachable.js";
 import { durationString } from "../helpers/durationString.js";
 import { getQueueChannel } from "../actions/queue/getQueueChannel.js";
 import { getQueueConfig } from "../useQueueStorage.js";
@@ -39,6 +40,17 @@ export const limits: Command = {
 						value = "infinite";
 					}
 					break;
+				case "queue-duration":
+					if (
+						config.queueDurationSeconds !== undefined &&
+						config.queueDurationSeconds !== null &&
+						config.queueDurationSeconds > 0
+					) {
+						value = durationString(config.queueDurationSeconds);
+					} else {
+						value = "infinite";
+					}
+					break;
 				case "count":
 					if (config.submissionMaxQuantity !== null && config.submissionMaxQuantity > 0) {
 						value = config.submissionMaxQuantity.toString();
@@ -46,6 +58,8 @@ export const limits: Command = {
 						value = "infinite";
 					}
 					break;
+				default:
+					assertUnreachable(key.value);
 			}
 
 			embed.addField(`${key.name}:\t${value}`, key.description);

--- a/src/commands/limits.ts
+++ b/src/commands/limits.ts
@@ -41,11 +41,7 @@ export const limits: Command = {
 					}
 					break;
 				case "queue-duration":
-					if (
-						config.queueDurationSeconds !== undefined &&
-						config.queueDurationSeconds !== null &&
-						config.queueDurationSeconds > 0
-					) {
+					if (config.queueDurationSeconds !== null && config.queueDurationSeconds > 0) {
 						value = durationString(config.queueDurationSeconds);
 					} else {
 						value = "infinite";

--- a/src/commands/queue/close.ts
+++ b/src/commands/queue/close.ts
@@ -31,6 +31,7 @@ export const close: GuildedSubcommand = {
 		const queueIsCurrent = channel?.id === queueChannel.id;
 		const promises: Array<Promise<unknown>> = [setQueueOpen(false, guild)];
 		if (!queueIsCurrent) {
+			// Post in the queue channel if this command wasn't run from there
 			promises.push(queueChannel.send("This queue is closed. :wave:"));
 		}
 		if (type === "interaction") {

--- a/src/commands/queue/limit.ts
+++ b/src/commands/queue/limit.ts
@@ -134,7 +134,7 @@ export const limit: Subcommand = {
 				// ** Limit the total queue duration
 				if (!valueOption) {
 					// Read the current limit
-					const value = config.queueDurationSeconds ?? null;
+					const value = config.queueDurationSeconds;
 					if (value === null) {
 						return reply("There is no limit on the queue's total duration.");
 					}

--- a/src/commands/queue/limit.ts
+++ b/src/commands/queue/limit.ts
@@ -1,5 +1,6 @@
 import type { CommandInteractionOption } from "discord.js";
 import type { Subcommand } from "../Command.js";
+import { assertUnreachable } from "../../helpers/assertUnreachable.js";
 import { composed, createPartialString, push, pushBold } from "../../helpers/composeStrings.js";
 import { durationString } from "../../helpers/durationString.js";
 import { SAFE_PRINT_LENGTH } from "../../constants/output.js";
@@ -10,7 +11,7 @@ import {
 	resolveStringFromOption
 } from "../../helpers/optionResolvers.js";
 
-type LimitKey = "entry-duration" | "cooldown" | "count";
+type LimitKey = "queue-duration" | "entry-duration" | "cooldown" | "count";
 
 export interface QueueLimitArg {
 	name: string;
@@ -20,15 +21,21 @@ export interface QueueLimitArg {
 
 export const allLimits: Array<QueueLimitArg> = [
 	{
+		name: "Total Queue Length",
+		value: "queue-duration",
+		description:
+			"The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit."
+	},
+	{
 		name: "Song Length",
 		value: "entry-duration",
-		description: "The maximum duration of a song submission."
+		description: "The maximum duration (in seconds) of a song submission."
 	},
 	{
 		name: "Submission Cooldown",
 		value: "cooldown",
 		description:
-			"The minimum amount of time that each user must wait between their own submissions."
+			"The minimum amount of time (in seconds) that each user must wait between their own submissions."
 	},
 	{
 		name: "Number of Submissions",
@@ -95,12 +102,12 @@ export const limit: Subcommand = {
 		// Set limits on the queue
 		switch (key) {
 			case "entry-duration": {
-				// Limit each duration entry
+				// ** Limit each entry's duration
 				if (!valueOption) {
 					// Read the current limit
 					const value = config.entryDurationSeconds;
 					if (value === null) {
-						return reply(`There is no limit on entry duration.`);
+						return reply("There is no limit on entry duration.");
 					}
 					return reply(`Entry duration limit is **${durationString(value)}**`);
 				}
@@ -123,8 +130,37 @@ export const limit: Subcommand = {
 				return reply(composed(response));
 			}
 
+			case "queue-duration": {
+				// ** Limit the total queue duration
+				if (!valueOption) {
+					// Read the current limit
+					const value = config.queueDurationSeconds ?? null;
+					if (value === null) {
+						return reply("There is no limit on the queue's total duration.");
+					}
+					return reply(`Queue duration limit is **${durationString(value)}**`);
+				}
+
+				// Set a new limit
+				let value = resolveIntegerFromOption(valueOption);
+				if (value !== null && Number.isNaN(value)) {
+					return reply("That doesn't look like an integer. Enter a number value in seconds.");
+				}
+				value = value === null || value <= 0 ? null : value;
+				await updateQueueConfig({ queueDurationSeconds: value }, queueChannel);
+
+				const response = createPartialString("Queue duration limit ");
+				if (value === null || value <= 0) {
+					pushBold("removed", response);
+				} else {
+					push("set to ", response);
+					pushBold(durationString(value), response);
+				}
+				return reply(composed(response));
+			}
+
 			case "cooldown": {
-				// Limit submission cooldown
+				// ** Limit submission cooldown
 				if (!valueOption) {
 					// Read the current limit
 					const value = config.cooldownSeconds;
@@ -154,7 +190,7 @@ export const limit: Subcommand = {
 			}
 
 			case "count": {
-				// Limit submission count per user
+				// ** Limit submission count per user
 				if (!valueOption) {
 					// Read the current limit
 					const value = config.submissionMaxQuantity;
@@ -182,6 +218,9 @@ export const limit: Subcommand = {
 				}
 				return reply(composed(response));
 			}
+
+			default:
+				assertUnreachable(key);
 		}
 	}
 };

--- a/src/commands/queue/limit.ts
+++ b/src/commands/queue/limit.ts
@@ -21,15 +21,9 @@ export interface QueueLimitArg {
 
 export const allLimits: Array<QueueLimitArg> = [
 	{
-		name: "Total Queue Length",
-		value: "queue-duration",
-		description:
-			"The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit."
-	},
-	{
-		name: "Song Length",
-		value: "entry-duration",
-		description: "The maximum duration (in seconds) of a song submission."
+		name: "Number of Submissions",
+		value: "count",
+		description: "The maximum number of submissions that each user may submit."
 	},
 	{
 		name: "Submission Cooldown",
@@ -38,9 +32,15 @@ export const allLimits: Array<QueueLimitArg> = [
 			"The minimum amount of time (in seconds) that each user must wait between their own submissions."
 	},
 	{
-		name: "Number of Submissions",
-		value: "count",
-		description: "The maximum number of submissions that each user may submit."
+		name: "Song Length",
+		value: "entry-duration",
+		description: "The maximum duration (in seconds) of a song submission."
+	},
+	{
+		name: "Total Queue Length",
+		value: "queue-duration",
+		description:
+			"The maximum duration (in seconds) that the queue should take if all its entries were played end-to-end. The queue will automatically close when a submission takes the queue over this limit."
 	}
 ];
 

--- a/src/commands/songRequest.test.ts
+++ b/src/commands/songRequest.test.ts
@@ -1,15 +1,16 @@
-jest.mock("../useGuildStorage");
-jest.mock("../useQueueStorage");
-jest.mock("../actions/queue/getQueueChannel");
-jest.mock("../actions/queue/useQueue");
-jest.mock("../actions/getVideoDetails");
+jest.mock("../useGuildStorage.js");
+jest.mock("../useQueueStorage.js");
+jest.mock("../actions/queue/getQueueChannel.js");
+jest.mock("../actions/queue/useQueue.js");
+jest.mock("../actions/getVideoDetails.js");
 
 import { countAllEntriesFrom, fetchLatestEntryFrom, getQueueConfig } from "../useQueueStorage.js";
 const mockQueueUserEntryCount = countAllEntriesFrom as jest.Mock;
 const mockGetQueueConfig = getQueueConfig as jest.Mock;
 const mockQueueGetLatestUserEntry = fetchLatestEntryFrom as jest.Mock;
 
-import { pushEntryToQueue } from "../actions/queue/useQueue.js";
+import { playtimeTotalInQueue, pushEntryToQueue } from "../actions/queue/useQueue.js";
+const mockPlaytimeTotal = playtimeTotalInQueue as jest.Mock;
 const mockQueuePush = pushEntryToQueue as jest.Mock;
 
 import { isQueueOpen } from "../useGuildStorage.js";
@@ -67,6 +68,7 @@ describe("Song request via URL", () => {
 	mockQueueGetLatestUserEntry.mockResolvedValue(null);
 	mockQueueUserEntryCount.mockResolvedValue(0);
 
+	mockPlaytimeTotal.mockResolvedValue(0);
 	mockIsQueueOpen.mockResolvedValue(true);
 
 	const queueChannel = {
@@ -77,6 +79,7 @@ describe("Song request via URL", () => {
 
 	mockGetQueueConfig.mockResolvedValue({
 		entryDurationSeconds: null,
+		queueDurationSeconds: null,
 		cooldownSeconds: 600,
 		submissionMaxQuantity: null,
 		blacklistedUsers: []

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -19,10 +19,9 @@ export const version: Command = {
 		if (type === "interaction") {
 			// Discord lets bots link stuff in Markdown syntax, but it'll also embed by default. Use `<brackets>` to prevent the embed.
 			const repo = "https://github.com/AverageHelper/Gamgee";
-			const source = `${repo}/tree/v${gamgeeVersion}`;
 			const changelog = `${repo}/releases/tag/v${gamgeeVersion}`;
 			return reply(
-				`I'm currently running [Gamgee Core v${gamgeeVersion}](<${source}>)  ${celebration}\nYou can [read the changelog](<${changelog}>) on GitHub!`
+				`I'm currently running [Gamgee Core v${gamgeeVersion}](<${changelog}>)  ${celebration}`
 			);
 		}
 

--- a/src/constants/queues.ts
+++ b/src/constants/queues.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_ENTRY_DURATION: number | null = null;
+export const DEFAULT_QUEUE_DURATION: number | null = null;
 export const DEFAULT_SUBMISSION_COOLDOWN: number | null = null;
 export const DEFAULT_SUBMISSION_MAX_QUANTITY: number | null = null;

--- a/src/database/DatabaseLogger.ts
+++ b/src/database/DatabaseLogger.ts
@@ -1,6 +1,9 @@
 import type { Logger as GamgeeLogger } from "../logger.js";
 import type { Logger as TypeORMLogger } from "typeorm";
 
+/**
+ * A TypeORM logger class that wraps a Winston logger instance.
+ */
 export class DatabaseLogger implements TypeORMLogger {
 	private readonly logger: GamgeeLogger;
 

--- a/src/database/migrations/1650745980666-add-queue-duration-limit.ts
+++ b/src/database/migrations/1650745980666-add-queue-duration-limit.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addQueueDurationLimit1650745980666 implements MigrationInterface {
+    name = 'addQueueDurationLimit1650745980666'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "temporary_queue-configs" ("channelId" varchar PRIMARY KEY NOT NULL, "entryDurationSeconds" integer, "cooldownSeconds" integer, "submissionMaxQuantity" integer, "queueDurationSeconds" integer)`);
+        await queryRunner.query(`INSERT INTO "temporary_queue-configs"("channelId", "entryDurationSeconds", "cooldownSeconds", "submissionMaxQuantity") SELECT "channelId", "entryDurationSeconds", "cooldownSeconds", "submissionMaxQuantity" FROM "queue-configs"`);
+        await queryRunner.query(`DROP TABLE "queue-configs"`);
+        await queryRunner.query(`ALTER TABLE "temporary_queue-configs" RENAME TO "queue-configs"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "queue-configs" RENAME TO "temporary_queue-configs"`);
+        await queryRunner.query(`CREATE TABLE "queue-configs" ("channelId" varchar PRIMARY KEY NOT NULL, "entryDurationSeconds" integer, "cooldownSeconds" integer, "submissionMaxQuantity" integer)`);
+        await queryRunner.query(`INSERT INTO "queue-configs"("channelId", "entryDurationSeconds", "cooldownSeconds", "submissionMaxQuantity") SELECT "channelId", "entryDurationSeconds", "cooldownSeconds", "submissionMaxQuantity" FROM "temporary_queue-configs"`);
+        await queryRunner.query(`DROP TABLE "temporary_queue-configs"`);
+    }
+
+}

--- a/src/database/migrations/index.ts
+++ b/src/database/migrations/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./1650745980666-add-queue-duration-limit.js";

--- a/src/database/model/QueueConfig.ts
+++ b/src/database/model/QueueConfig.ts
@@ -13,7 +13,7 @@ export class QueueConfig {
 
 	/** The maximum time in seconds that the queue can take if all its entries were played end-to-end. */
 	@Column({ type: "integer", nullable: true })
-	queueDurationSeconds?: number | null;
+	queueDurationSeconds: number | null;
 
 	/** The number of seconds that a user must wait between successful queue submissions. */
 	@Column({ type: "integer", nullable: true })

--- a/src/database/model/QueueConfig.ts
+++ b/src/database/model/QueueConfig.ts
@@ -11,6 +11,10 @@ export class QueueConfig {
 	@Column({ type: "integer", nullable: true })
 	entryDurationSeconds: number | null;
 
+	/** The maximum time in seconds that the queue can take if all its entries were played end-to-end. */
+	@Column({ type: "integer", nullable: true })
+	queueDurationSeconds?: number | null;
+
 	/** The number of seconds that a user must wait between successful queue submissions. */
 	@Column({ type: "integer", nullable: true })
 	cooldownSeconds: number | null;
@@ -26,13 +30,13 @@ export class QueueConfig {
 		nullable: false
 	})
 	@JoinTable()
-	blacklistedUsers?: Array<User>;
-	// FIXME: `blacklistedUsers` is undefined on a fresh database
+	blacklistedUsers?: Array<User>; // `blacklistedUsers` is undefined on a fresh database
 
 	constructor(channelId: string, config: Omit<QueueConfig, "channelId">);
 	constructor(channelId?: string, config?: Omit<QueueConfig, "channelId">) {
 		this.channelId = channelId ?? "";
 		this.entryDurationSeconds = config?.entryDurationSeconds ?? null;
+		this.queueDurationSeconds = config?.queueDurationSeconds ?? null;
 		this.cooldownSeconds = config?.cooldownSeconds ?? null;
 		this.submissionMaxQuantity = config?.submissionMaxQuantity ?? null;
 	}

--- a/src/useQueueStorage.ts
+++ b/src/useQueueStorage.ts
@@ -6,6 +6,7 @@ import { useRepository, useTransaction } from "./database/useDatabase.js";
 import { useLogger } from "./logger.js";
 import {
 	DEFAULT_ENTRY_DURATION,
+	DEFAULT_QUEUE_DURATION,
 	DEFAULT_SUBMISSION_COOLDOWN,
 	DEFAULT_SUBMISSION_MAX_QUANTITY
 } from "./constants/queues.js";
@@ -41,6 +42,7 @@ export async function getQueueConfig(
 	const defaultConfig = (): QueueConfig =>
 		new QueueConfig(channelId, {
 			entryDurationSeconds: DEFAULT_ENTRY_DURATION,
+			queueDurationSeconds: DEFAULT_QUEUE_DURATION,
 			cooldownSeconds: DEFAULT_SUBMISSION_COOLDOWN,
 			submissionMaxQuantity: DEFAULT_SUBMISSION_MAX_QUANTITY,
 			blacklistedUsers: []
@@ -71,6 +73,13 @@ export async function updateQueueConfig(
 			entryDurationSeconds = config.entryDurationSeconds;
 		}
 
+		let queueDurationSeconds: number | null;
+		if (config.queueDurationSeconds === undefined) {
+			queueDurationSeconds = oldConfig.queueDurationSeconds ?? null;
+		} else {
+			queueDurationSeconds = config.queueDurationSeconds;
+		}
+
 		let cooldownSeconds: number | null;
 		if (config.cooldownSeconds === undefined) {
 			cooldownSeconds = oldConfig.cooldownSeconds;
@@ -94,6 +103,7 @@ export async function updateQueueConfig(
 
 		const newConfig = new QueueConfig(queueChannel.id, {
 			entryDurationSeconds,
+			queueDurationSeconds,
 			cooldownSeconds,
 			submissionMaxQuantity,
 			blacklistedUsers
@@ -136,6 +146,7 @@ export async function createEntry(
 		const defaultConfig = (): QueueConfig =>
 			new QueueConfig(queueChannel.id, {
 				entryDurationSeconds: DEFAULT_ENTRY_DURATION,
+				queueDurationSeconds: DEFAULT_QUEUE_DURATION,
 				cooldownSeconds: DEFAULT_SUBMISSION_COOLDOWN,
 				submissionMaxQuantity: DEFAULT_SUBMISSION_MAX_QUANTITY,
 				blacklistedUsers: []

--- a/tests/discordUtils/testerClient.ts
+++ b/tests/discordUtils/testerClient.ts
@@ -1,4 +1,5 @@
 import Discord from "discord.js";
+import { MILLISECONDS_IN_SECOND } from "../../src/constants/time.js";
 import { requireEnv } from "../../src/helpers/environment.js";
 import { useDispatchLoop } from "./dispatchLoop.js";
 
@@ -60,8 +61,9 @@ export async function testerClient(): Promise<Discord.Client> {
 /**
  * Logs out of the tester bot's Discord client.
  */
-export function logOut(): void {
+export async function logOut(): Promise<void> {
 	if (isClientLoggedIn) {
 		client.destroy();
+		await new Promise(resolve => setTimeout(resolve, MILLISECONDS_IN_SECOND)); // die after 1s
 	}
 }

--- a/tests/setupJest.ts
+++ b/tests/setupJest.ts
@@ -7,6 +7,6 @@ logger.info(`Node ${process.version}`);
 // 45-second timeout for E2E tests
 jest.setTimeout(45000);
 
-afterAll(() => {
-	logOut();
+afterAll(async () => {
+	await logOut();
 });


### PR DESCRIPTION
* Added a configurable limit to the queue's total estimated playtime
  * If a submission would take the total playtime over the configured limit, then Gamgee closes the queue.
  * Remove the limit in the same way you remove other limits: set them to `0` or `null`.
* Made `/version` readout less verbose
* Gamgee no longer adds "(Reply from ...)" when the original channel was already a DM
* Fixed migration errors. You should be able to run `npm run migrate` or `npm run setup` now without issues!