### PR TITLE
Fix command deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gamgee",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gamgee",
-			"version": "1.6.0",
+			"version": "1.6.1",
 			"license": "LICENSE",
 			"dependencies": {
 				"@averagehelper/job-queue": "^0.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gamgee",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "A Discord bot for managing a song request queue.",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
Due to [discord-api-docs#4830](https://github.com/discord/discord-api-docs/pull/4830), we no longer try to set app command permissions. We'll handle that with the same runtime fallback that message command permissions use.

In the future, we may set the default command permissions using new API constructs, and lean on Discord's UI to let guild admins configure command permissions as they see fit.
