### PR TITLE
Rollup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,21 @@ jobs:
           QUEUE_ADMIN_ROLE_ID: ${{ secrets.QUEUE_ADMIN_ROLE_ID }}
           QUEUE_CREATOR_ROLE_ID: ${{ secrets.QUEUE_CREATOR_ROLE_ID }}
           BOT_PREFIX: "?"
+
+      # Try again with the minified build
+      - run: npm run build --production
+      - run: npm run test:e2e
+        env:
+          CI: true
+          NODE_ENV: "test"
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          SOUNDCLOUD_API_KEY: ${{ secrets.SOUNDCLOUD_API_KEY }}
+          CORDE_TEST_TOKEN: ${{ secrets.CORDE_TEST_TOKEN }}
+          CORDE_BOT_ID: ${{ secrets.CORDE_BOT_ID }}
+          BOT_TEST_ID: ${{ secrets.BOT_TEST_ID }}
+          GUILD_ID: ${{ secrets.GUILD_ID }}
+          CHANNEL_ID: ${{ secrets.CHANNEL_ID }}
+          QUEUE_CHANNEL_ID: ${{ secrets.QUEUE_CHANNEL_ID }}
+          QUEUE_ADMIN_ROLE_ID: ${{ secrets.QUEUE_ADMIN_ROLE_ID }}
+          QUEUE_CREATOR_ROLE_ID: ${{ secrets.QUEUE_CREATOR_ROLE_ID }}
+          BOT_PREFIX: "?"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/version.ts
 tmp
 temp
 .vs
+stats.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
 	"i18n-ally.keystyle": "nested",
 	"i18n-ally.localesPaths": ["src/locales"],
 	"i18n-ally.sourceLanguage": "en-US",
-	"i18n-ally.tabStyle": "tab"
+	"i18n-ally.tabStyle": "tab",
+	"todo-tree.filtering.excludeGlobs": ["**/dist/**"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Replaced the `DATABASE_FOLDER` environment variable with a new required `DATABASE_URL` variable. Please add this variable to your `.env` file, and set it to the value `"file:{absolute path to your database file}"`. See the [README](/README.md#selecting-a-database-file-location) for an example.
 - Renamed the `entry-duration` queue limit ID to `entry-duration-max`. This makes more sense alongside the `entry-duration-min` limit ID.
 - Since [Node 18 supports a built-in `fetch` API](https://dev.to/andrewbaisden/the-nodejs-18-fetch-api-72m), we'll use that when its available. We fall back to `cross-fetch` otherwise.
+- The build output is now a single file, dist/server.js.
 
 ### Removed
 - BREAKING: Removed migrations from old v1.x.x versions. You should **run Gamgee v1.8.3** at least once if you're updating from an older Gamgee version and want to keep your database.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
 	apps: [
 		{
 			name: "gamgee",
-			script: "./dist/main.js",
+			script: "./dist/server.js",
 			cwd: __dirname,
 			source_map_support: true,
 			watch: ["dist"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,10 @@
 				"ytdl-core": "4.11.2"
 			},
 			"devDependencies": {
+				"@rollup/plugin-commonjs": "22.0.2",
+				"@rollup/plugin-json": "4.1.0",
+				"@rollup/plugin-node-resolve": "14.1.0",
+				"@rollup/plugin-typescript": "8.5.0",
 				"@types/chai": "4.3.3",
 				"@types/humanize-duration": "3.27.1",
 				"@types/jest": "28.1.6",
@@ -60,6 +64,10 @@
 				"nodemon": "2.0.19",
 				"prettier": "2.7.1",
 				"prisma": "4.3.1",
+				"rollup": "2.79.0",
+				"rollup-plugin-analyzer": "4.0.0",
+				"rollup-plugin-terser": "7.0.2",
+				"rollup-plugin-visualizer": "5.8.1",
 				"semver": "7.3.7",
 				"ts-jest": "28.0.7",
 				"ts-node": "10.9.1",
@@ -1327,6 +1335,30 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
@@ -1409,6 +1441,105 @@
 			"version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
 			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
 			"integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
+		},
+		"node_modules/@rollup/plugin-commonjs": {
+			"version": "22.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+			"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.68.0"
+			}
+		},
+		"node_modules/@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.0.8"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz",
+			"integrity": "sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"deepmerge": "^4.2.2",
+				"is-builtin-module": "^3.1.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.78.0"
+			}
+		},
+		"node_modules/@rollup/plugin-typescript": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
+			"integrity": "sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"resolve": "^1.17.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.14.0",
+				"tslib": "*",
+				"typescript": ">=3.7.0"
+			},
+			"peerDependenciesMeta": {
+				"tslib": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
 		},
 		"node_modules/@sapphire/async-queue": {
 			"version": "1.5.0",
@@ -1541,6 +1672,12 @@
 			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
 			"dev": true
 		},
+		"node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1624,6 +1761,15 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
 			"integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
 			"dev": true
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.12",
@@ -2789,6 +2935,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2961,6 +3113,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -3881,6 +4042,12 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4487,6 +4654,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4525,6 +4707,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+			"dev": true
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4541,6 +4729,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*"
 			}
 		},
 		"node_modules/is-stream": {
@@ -4561,6 +4758,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/isexe": {
@@ -5506,6 +5715,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6046,6 +6264,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/open": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"dev": true,
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -6511,6 +6746,115 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rollup": {
+			"version": "2.79.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
+			"integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rollup-plugin-analyzer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz",
+			"integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/rollup-plugin-terser": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.0.0"
+			}
+		},
+		"node_modules/rollup-plugin-terser/node_modules/jest-worker": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/rollup-plugin-visualizer": {
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.8.1.tgz",
+			"integrity": "sha512-NBT/xN/LWCwDM2/j5vYmjzpEAKHyclo/8Cv8AfTCwgADAG+tLJDy1vzxMw6NO0dSDjmTeRELD9UU3FwknLv0GQ==",
+			"dev": true,
+			"dependencies": {
+				"nanoid": "^3.3.4",
+				"open": "^8.4.0",
+				"source-map": "^0.7.3",
+				"yargs": "^17.5.1"
+			},
+			"bin": {
+				"rollup-plugin-visualizer": "dist/bin/cli.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"rollup": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/rollup-plugin-visualizer/node_modules/nanoid": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"dev": true,
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6714,6 +7058,12 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"node_modules/spawn-command": {
 			"version": "0.0.2-1",
@@ -6953,6 +7303,30 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/terser": {
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -8567,6 +8941,29 @@
 			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
 			"dev": true
 		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/gen-mapping": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/sourcemap-codec": "^1.4.10",
+						"@jridgewell/trace-mapping": "^0.3.9"
+					}
+				}
+			}
+		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
@@ -8627,6 +9024,73 @@
 			"version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
 			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
 			"integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
+		},
+		"@rollup/plugin-commonjs": {
+			"version": "22.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+			"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.0.8"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz",
+			"integrity": "sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"deepmerge": "^4.2.2",
+				"is-builtin-module": "^3.1.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			}
+		},
+		"@rollup/plugin-typescript": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
+			"integrity": "sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
 		},
 		"@sapphire/async-queue": {
 			"version": "1.5.0",
@@ -8747,6 +9211,12 @@
 			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
 			"dev": true
 		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
 		"@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8830,6 +9300,15 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
 			"integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
 			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/semver": {
 			"version": "7.3.12",
@@ -9648,6 +10127,12 @@
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"dev": true
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9779,6 +10264,12 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
+		},
+		"define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
 			"dev": true
 		},
 		"detect-newline": {
@@ -10417,6 +10908,12 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10869,6 +11366,12 @@
 				"has": "^1.0.3"
 			}
 		},
+		"is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -10895,6 +11398,12 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -10907,6 +11416,15 @@
 			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true
 		},
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
 		"is-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -10917,6 +11435,15 @@
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
 			"dev": true
+		},
+		"is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -11649,6 +12176,15 @@
 				"sax": "^1.2.4"
 			}
 		},
+		"magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12038,6 +12574,17 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
+		"open": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"dev": true,
+			"requires": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			}
+		},
 		"p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -12358,6 +12905,81 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"rollup": {
+			"version": "2.79.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
+			"integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"rollup-plugin-analyzer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz",
+			"integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
+			"dev": true
+		},
+		"rollup-plugin-terser": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
+			},
+			"dependencies": {
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				}
+			}
+		},
+		"rollup-plugin-visualizer": {
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.8.1.tgz",
+			"integrity": "sha512-NBT/xN/LWCwDM2/j5vYmjzpEAKHyclo/8Cv8AfTCwgADAG+tLJDy1vzxMw6NO0dSDjmTeRELD9UU3FwknLv0GQ==",
+			"dev": true,
+			"requires": {
+				"nanoid": "^3.3.4",
+				"open": "^8.4.0",
+				"source-map": "^0.7.3",
+				"yargs": "^17.5.1"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+					"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+					"dev": true
+				}
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12524,6 +13146,12 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
@@ -12713,6 +13341,26 @@
 			"requires": {
 				"ansi-escapes": "^4.2.1",
 				"supports-hyperlinks": "^2.0.0"
+			}
+		},
+		"terser": {
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				}
 			}
 		},
 		"test-exclude": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"start": "NODE_ENV=development ./node_modules/.bin/nodemon --inspect dist/server.js",
-		"setup": "npm ci && npm run export-version && npm run build && npm run baseline && npm run migrate && npm run commands:deploy",
+		"setup": "npm ci && npm run export-version && npm run build --production && npm run baseline && npm run migrate && npm run commands:deploy",
 		"commands:deploy": "node . --deploy-commands",
 		"commands:revoke": "node . --revoke-commands",
 		"release": "./node_modules/.bin/ts-node -P tsconfig.test.json ./scripts/release.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"start": "NODE_ENV=development ./node_modules/.bin/nodemon --inspect dist/server.js",
-		"setup": "npm ci && npm run export-version && npm run build --production && npm run baseline && npm run migrate && npm run commands:deploy",
+		"setup": "npm ci && npm run export-version && npm run build:only --production && npm run baseline && npm run migrate && npm run commands:deploy",
 		"commands:deploy": "node . --deploy-commands",
 		"commands:revoke": "node . --revoke-commands",
 		"release": "./node_modules/.bin/ts-node -P tsconfig.test.json ./scripts/release.ts",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"description": "A Discord bot for managing a song request queue.",
 	"private": true,
 	"scripts": {
-		"start": "NODE_ENV=development ./node_modules/.bin/nodemon --inspect dist/main.js",
-		"setup": "npm ci && npm run export-version && npm run build:clean && npm run baseline && npm run migrate && npm run commands:deploy",
+		"start": "NODE_ENV=development ./node_modules/.bin/nodemon --inspect dist/server.js",
+		"setup": "npm ci && npm run export-version && npm run build && npm run baseline && npm run migrate && npm run commands:deploy",
 		"commands:deploy": "node . --deploy-commands",
 		"commands:revoke": "node . --revoke-commands",
 		"release": "./node_modules/.bin/ts-node -P tsconfig.test.json ./scripts/release.ts",
@@ -19,8 +19,7 @@
 		"lintonly": "./node_modules/.bin/eslint . --ext .ts",
 		"prebuild": "npm run lint",
 		"build": "npm run build:only",
-		"build:only": "./node_modules/.bin/tsc -p tsconfig.prod.json",
-		"build:clean": "rm -rf dist && npm run build",
+		"build:only": "./node_modules/.bin/rollup --config rollup.config.ts --configPlugin typescript",
 		"export-version": "./node_modules/.bin/genversion ./src/version.ts -esd",
 		"test": "npm run test:src && npm run test:e2e",
 		"test:src": "export DATABASE_URL=\"file:$(pwd)/tests/db-test/db.sqlite\"; ./node_modules/.bin/prisma migrate reset --force && ./node_modules/.bin/jest",
@@ -29,7 +28,7 @@
 		"start:test": "export DATABASE_URL=\"file:$(pwd)/tests/db-test/db.sqlite\"; export NODE_ENV=test; ./node_modules/.bin/prisma migrate reset --force && node .",
 		"_test:e2e": "TS_NODE_PROJECT='./tsconfig.e2e.json' ./node_modules/.bin/mocha"
 	},
-	"main": "./dist/main.js",
+	"main": "./dist/server.js",
 	"type": "commonjs",
 	"engines": {
 		"node": ">=16.10"
@@ -68,6 +67,10 @@
 		"ytdl-core": "4.11.2"
 	},
 	"devDependencies": {
+		"@rollup/plugin-commonjs": "22.0.2",
+		"@rollup/plugin-json": "4.1.0",
+		"@rollup/plugin-node-resolve": "14.1.0",
+		"@rollup/plugin-typescript": "8.5.0",
 		"@types/chai": "4.3.3",
 		"@types/humanize-duration": "3.27.1",
 		"@types/jest": "28.1.6",
@@ -99,6 +102,10 @@
 		"nodemon": "2.0.19",
 		"prettier": "2.7.1",
 		"prisma": "4.3.1",
+		"rollup": "2.79.0",
+		"rollup-plugin-analyzer": "4.0.0",
+		"rollup-plugin-terser": "7.0.2",
+		"rollup-plugin-visualizer": "5.8.1",
 		"semver": "7.3.7",
 		"ts-jest": "28.0.7",
 		"ts-node": "10.9.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -40,14 +40,13 @@ export default defineConfig({
 		// Weirdness
 		"@prisma/client",
 
+		// Curcular, uses eval
+		"discord.js",
+
 		// Circular
 		"undici",
-		"@discordjs/builders",
-		"@discordjs/rest",
-		"discord.js",
 		"winston-transport",
 		"winston",
-		"async",
 		"yargs"
 	],
 	input: "src/main.ts",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
 		defaultHandler(warning);
 	},
 	external: [
-		// Curcular, uses eval
+		// Circular, uses eval
 		"discord.js",
 
 		// Circular

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,10 +7,15 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import typescript from "@rollup/plugin-typescript";
 
+const isProduction = process.env["NODE_ENV"] === "production";
+
 export default defineConfig({
 	plugins: [
 		// Transpile source
-		typescript({ tsconfig: "./tsconfig.prod.json" }), // translate TypeScript to JS
+		typescript({
+			tsconfig: "./tsconfig.prod.json",
+			sourceMap: !isProduction
+		}), // translate TypeScript to JS
 		commonjs({ extensions: [".js", ".ts"] }), // translate CommonJS to ESM
 		json(), // translate JSON
 
@@ -58,6 +63,6 @@ export default defineConfig({
 		file: "dist/server.js",
 		format: "commonjs",
 		inlineDynamicImports: true,
-		sourcemap: "inline"
+		sourcemap: isProduction ? undefined : "inline"
 	}
 });

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig } from "rollup";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import { terser } from "rollup-plugin-terser";
+import { visualizer } from "rollup-plugin-visualizer";
+import analyze from "rollup-plugin-analyzer";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import typescript from "@rollup/plugin-typescript";
+
+export default defineConfig({
+	plugins: [
+		// Transpile source
+		typescript({ tsconfig: "./tsconfig.prod.json" }), // translate TypeScript to JS
+		commonjs({ extensions: [".js", ".ts"] }), // translate CommonJS to ESM
+		json(), // translate JSON
+
+		// // Find external dependencies
+		nodeResolve({
+			exportConditions: ["node"],
+			preferBuiltins: true
+		}),
+
+		// // Minify output
+		process.env["NODE_ENV"] === "production" ? terser() : null,
+
+		// Statistics
+		analyze({ filter: () => false }), // only top-level summary
+		visualizer()
+	],
+	onwarn(warning, defaultHandler) {
+		// Ignore "`this` has been rewritten to `undefined`" warnings.
+		// They usually relate to modules that were transpiled from
+		// TypeScript, and check their context by querying the value
+		// of global `this`.
+		if (warning.code === "THIS_IS_UNDEFINED") return;
+
+		defaultHandler(warning);
+	},
+	external: [
+		// Weirdness
+		"@prisma/client",
+
+		// Circular
+		"undici",
+		"@discordjs/builders",
+		"@discordjs/rest",
+		"discord.js",
+		"winston-transport",
+		"winston",
+		"async",
+		"yargs"
+	],
+	input: "src/main.ts",
+	output: {
+		file: "dist/server.js",
+		format: "commonjs",
+		inlineDynamicImports: true,
+		sourcemap: "inline"
+	}
+});

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,13 +14,13 @@ export default defineConfig({
 		commonjs({ extensions: [".js", ".ts"] }), // translate CommonJS to ESM
 		json(), // translate JSON
 
-		// // Find external dependencies
+		// Find external dependencies
 		nodeResolve({
 			exportConditions: ["node"],
 			preferBuiltins: true
 		}),
 
-		// // Minify output
+		// Minify output
 		process.env["NODE_ENV"] === "production" ? terser() : null,
 
 		// Statistics
@@ -32,14 +32,18 @@ export default defineConfig({
 		// They usually relate to modules that were transpiled from
 		// TypeScript, and check their context by querying the value
 		// of global `this`.
+		// TODO: PR @averagehelper/job-queue to fix this
 		if (warning.code === "THIS_IS_UNDEFINED") return;
+
+		// Ignore "Use of eval is strongly discouraged" warnings from
+		// prisma. Their `eval` calls are fairly tame, though this should
+		// be audited with each update.
+		const evalWhitelist = ["@prisma/client"];
+		if (warning.code === "EVAL" && evalWhitelist.some(e => warning.loc?.file?.includes(e))) return;
 
 		defaultHandler(warning);
 	},
 	external: [
-		// Weirdness
-		"@prisma/client",
-
 		// Curcular, uses eval
 		"discord.js",
 

--- a/src/actions/assertUserCanRunCommand.ts
+++ b/src/actions/assertUserCanRunCommand.ts
@@ -1,0 +1,112 @@
+import type { Command, CommandPermission, Subcommand } from "../commands/index.js";
+import type { GuildMember, GuildTextBasedChannel } from "discord.js";
+import { ApplicationCommandPermissionType } from "discord.js";
+import { assertUnreachable } from "../helpers/assertUnreachable.js";
+import { resolvePermissions } from "../commands/CommandPermission.js";
+import { useLogger } from "../logger.js";
+import {
+	userHasPermissionInChannel,
+	userHasRoleInGuild
+} from "../permissions/userHasOneOfRoles.js";
+
+export type Invocable = Command | Subcommand;
+
+const logger = useLogger();
+
+/**
+ * Assesses whether the calling guild member is allowed to run the given command.
+ *
+ * @param member The calling guild member.
+ * @param command The command the user wants to run.
+ * @param channel The channel in which the command is being run.
+ *
+ * @returns `true` if the user may be permitted to run the command. `false` otherwise.
+ */
+export async function assertUserCanRunCommand(
+	member: GuildMember,
+	command: Invocable,
+	channel: GuildTextBasedChannel | null
+): Promise<boolean> {
+	if (command.requiresGuild && !channel) {
+		logger.debug(`Command '${command.name}' reqires a guild, but we don't have one right now.`);
+		return false;
+	}
+
+	if (!command.permissions) {
+		// No permissions demanded
+		logger.debug(`Command '${command.name}' does not require specific user permissions.`);
+		logger.debug("Proceeding...");
+		return true;
+	}
+
+	const guild = channel?.guild;
+	const permissions: Array<CommandPermission> = guild
+		? Array.isArray(command.permissions)
+			? await resolvePermissions(command.permissions, guild)
+			: await command.permissions(guild)
+		: [];
+
+	logger.debug(
+		`Command '${command.name}' requires that callers satisfy 1 of ${permissions.length} cases:`
+	);
+
+	let idx = 0;
+	for (const access of permissions) {
+		idx += 1;
+		switch (access.type) {
+			case ApplicationCommandPermissionType.Role: {
+				logger.debug(
+					`\tCase ${idx}: User must${access.permission ? "" : " not"} have ROLE ID: ${access.id}`
+				);
+				const userHasRole =
+					guild !== undefined && (await userHasRoleInGuild(member, access.id, guild));
+				logger.debug(`\tUser ${userHasRole ? "has" : "does not have"} role ${access.id}`);
+				if (access.permission && userHasRole) {
+					logger.debug("\tProceeding...");
+					return true;
+				}
+				break;
+			}
+
+			case ApplicationCommandPermissionType.User: {
+				logger.debug(
+					`\tCase ${idx}: User must${access.permission ? "" : " not"} have USER ID: ${access.id}`
+				);
+				const userHasId = member.id === access.id;
+				logger.debug(`\tUser ${userHasId ? "has" : "does not have"} ID ${access.id}`);
+				if (access.permission && userHasId) {
+					logger.debug("\tProceeding...");
+					return true;
+				}
+				break;
+			}
+
+			case ApplicationCommandPermissionType.Channel: {
+				logger.debug(
+					`\tCase ${idx}: User must${
+						access.permission ? "" : " not"
+					} have 'ReadMessageHistory' access in CHANNEL ID: ${access.id}`
+				);
+				const userCanSeeChannel =
+					channel !== null && userHasPermissionInChannel(member, "ReadMessageHistory", access.id);
+				logger.debug(
+					`\tUser ${
+						userCanSeeChannel ? "has" : "does not have"
+					} permission to read messages in channel ${access.id}`
+				);
+				if (access.permission && channel) {
+					logger.debug("\tProceeding...");
+					return true;
+				}
+				break;
+			}
+
+			default:
+				return assertUnreachable(access.type);
+		}
+	}
+
+	// Caller fails permissions checks
+	logger.debug("User did not pass any permission checks.");
+	return false;
+}

--- a/src/actions/describeAllCommands.ts
+++ b/src/actions/describeAllCommands.ts
@@ -1,9 +1,14 @@
-import type Discord from "discord.js";
+import type {
+	ApplicationCommandChoicesData,
+	ApplicationCommandNonOptionsData,
+	ApplicationCommandOption,
+	ApplicationCommandOptionData
+} from "discord.js";
 import type { Command, CommandContext, Subcommand } from "../commands/index.js";
 import type { PartialString } from "../helpers/composeStrings.js";
 import type { SupportedLocale } from "../i18n.js";
 import { ApplicationCommandOptionType } from "discord.js";
-import { assertUserCanRunCommand } from "./invokeCommand.js";
+import { assertUserCanRunCommand } from "./assertUserCanRunCommand.js";
 import { getCommandPrefix } from "../useGuildStorage.js";
 import { isGuildedCommandContext } from "../commands/CommandContext.js";
 import { SLASH_COMMAND_INTENT_PREFIX } from "../constants/database.js";
@@ -143,10 +148,10 @@ export async function describeAllCommands(
 
 function describeParameters(
 	options: Array<
-		| Discord.ApplicationCommandOption
-		| Discord.ApplicationCommandOptionData
-		| Discord.ApplicationCommandChoicesData
-		| Discord.ApplicationCommandNonOptionsData
+		| ApplicationCommandOption
+		| ApplicationCommandOptionData
+		| ApplicationCommandChoicesData
+		| ApplicationCommandNonOptionsData
 		| Subcommand
 	>,
 	cmdDesc: PartialString,
@@ -155,7 +160,7 @@ function describeParameters(
 	options
 		?.filter(optn => optn.type !== ApplicationCommandOptionType.Subcommand)
 		?.forEach(o => {
-			const option = o as Discord.ApplicationCommandChoicesData;
+			const option = o as ApplicationCommandChoicesData;
 
 			// Describe the parameter
 			const subDesc = createPartialString();

--- a/src/actions/invokeCommand.test.ts
+++ b/src/actions/invokeCommand.test.ts
@@ -1,7 +1,7 @@
 jest.mock("../useGuildStorage");
 jest.mock("../permissions");
 
-import type Discord from "discord.js";
+import type { Guild, GuildMember, Role } from "discord.js";
 import type {
 	CommandContext,
 	CommandPermission,
@@ -18,7 +18,7 @@ const mockGetGuildAdminRoles = getGuildAdminRoles as jest.Mock;
 import { userHasRoleInGuild } from "../permissions/index.js";
 const mockUserHasRoleInGuild = userHasRoleInGuild as jest.Mock<
 	Promise<boolean>,
-	[user: Discord.GuildMember, roleId: string, guild: Discord.Guild]
+	[user: GuildMember, roleId: string, guild: Guild]
 >;
 
 const mockExecute = jest.fn<Promise<void>, Array<unknown>>().mockResolvedValue(undefined);
@@ -45,7 +45,7 @@ describe("Invoke Command", () => {
 			id: "the-guild",
 			ownerId: callerId,
 			roles: {
-				async fetch(id: string): Promise<Discord.Role | null> {
+				async fetch(id: string): Promise<Role | null> {
 					// Promise.reject(new Error("You shouldn't get here"))
 					const doesHave = await mockUserHasRoleInGuild(member, id, guild);
 					return {
@@ -53,15 +53,15 @@ describe("Invoke Command", () => {
 						members: {
 							has: () => doesHave
 						}
-					} as unknown as Discord.Role;
+					} as unknown as Role;
 				}
 			}
-		} as unknown as Discord.Guild;
+		} as unknown as Guild;
 
 		const member = {
 			id: callerId,
 			guild
-		} as unknown as Discord.GuildMember;
+		} as unknown as GuildMember;
 
 		context = {
 			user: {
@@ -106,7 +106,7 @@ describe("Invoke Command", () => {
 	describe("Permission Guards", () => {
 		const mockPermissions = jest.fn<
 			Array<CommandPermission> | Promise<Array<CommandPermission>>,
-			[guild: Discord.Guild]
+			[guild: Guild]
 		>();
 
 		beforeEach(() => {
@@ -116,7 +116,7 @@ describe("Invoke Command", () => {
 				guild: {
 					id: "the-guild",
 					ownerId: callerId
-				} as unknown as Discord.Guild
+				} as unknown as Guild
 			};
 			command.permissions = mockPermissions;
 

--- a/src/actions/invokeCommand.ts
+++ b/src/actions/invokeCommand.ts
@@ -1,18 +1,11 @@
-import type Discord from "discord.js";
-import type { Command, CommandContext, CommandPermission, Subcommand } from "../commands/index.js";
-import { ApplicationCommandPermissionType } from "discord.js";
-import { assertUnreachable } from "../helpers/assertUnreachable.js";
-import { isGuildedCommandContext, resolvePermissions } from "../commands/index.js";
+import type { CommandContext } from "../commands/index.js";
+import type { Invocable } from "./assertUserCanRunCommand.js";
+import { assertUserCanRunCommand } from "./assertUserCanRunCommand.js";
+import { isGuildedCommandContext } from "../commands/CommandContext.js";
 import { t } from "../i18n.js";
 import { useLogger } from "../logger.js";
-import {
-	userHasPermissionInChannel,
-	userHasRoleInGuild
-} from "../permissions/userHasOneOfRoles.js";
 
 const logger = useLogger();
-
-type Invocable = Command | Subcommand;
 
 async function failPermissions(context: CommandContext): Promise<void> {
 	return await context.replyPrivately({
@@ -26,104 +19,6 @@ async function failNoGuild(context: CommandContext): Promise<void> {
 		content: t("common.not-here", context.userLocale),
 		ephemeral: true
 	});
-}
-
-/**
- * Assesses whether the calling guild member is allowed to run the given command.
- *
- * @param member The calling guild member.
- * @param command The command the user wants to run.
- * @param channel The channel in which the command is being run.
- *
- * @returns `true` if the user may be permitted to run the command. `false` otherwise.
- */
-export async function assertUserCanRunCommand(
-	member: Discord.GuildMember,
-	command: Invocable,
-	channel: Discord.GuildTextBasedChannel | null
-): Promise<boolean> {
-	if (command.requiresGuild && !channel) {
-		logger.debug(`Command '${command.name}' reqires a guild, but we don't have one right now.`);
-		return false;
-	}
-
-	if (!command.permissions) {
-		// No permissions demanded
-		logger.debug(`Command '${command.name}' does not require specific user permissions.`);
-		logger.debug("Proceeding...");
-		return true;
-	}
-
-	const guild = channel?.guild;
-	const permissions: Array<CommandPermission> = guild
-		? Array.isArray(command.permissions)
-			? await resolvePermissions(command.permissions, guild)
-			: await command.permissions(guild)
-		: [];
-
-	logger.debug(
-		`Command '${command.name}' requires that callers satisfy 1 of ${permissions.length} cases:`
-	);
-
-	let idx = 0;
-	for (const access of permissions) {
-		idx += 1;
-		switch (access.type) {
-			case ApplicationCommandPermissionType.Role: {
-				logger.debug(
-					`\tCase ${idx}: User must${access.permission ? "" : " not"} have ROLE ID: ${access.id}`
-				);
-				const userHasRole =
-					guild !== undefined && (await userHasRoleInGuild(member, access.id, guild));
-				logger.debug(`\tUser ${userHasRole ? "has" : "does not have"} role ${access.id}`);
-				if (access.permission && userHasRole) {
-					logger.debug("\tProceeding...");
-					return true;
-				}
-				break;
-			}
-
-			case ApplicationCommandPermissionType.User: {
-				logger.debug(
-					`\tCase ${idx}: User must${access.permission ? "" : " not"} have USER ID: ${access.id}`
-				);
-				const userHasId = member.id === access.id;
-				logger.debug(`\tUser ${userHasId ? "has" : "does not have"} ID ${access.id}`);
-				if (access.permission && userHasId) {
-					logger.debug("\tProceeding...");
-					return true;
-				}
-				break;
-			}
-
-			case ApplicationCommandPermissionType.Channel: {
-				logger.debug(
-					`\tCase ${idx}: User must${
-						access.permission ? "" : " not"
-					} have 'ReadMessageHistory' access in CHANNEL ID: ${access.id}`
-				);
-				const userCanSeeChannel =
-					channel !== null && userHasPermissionInChannel(member, "ReadMessageHistory", access.id);
-				logger.debug(
-					`\tUser ${
-						userCanSeeChannel ? "has" : "does not have"
-					} permission to read messages in channel ${access.id}`
-				);
-				if (access.permission && channel) {
-					logger.debug("\tProceeding...");
-					return true;
-				}
-				break;
-			}
-
-			default:
-				return assertUnreachable(access.type);
-		}
-	}
-
-	// Caller fails permissions checks
-	logger.debug("User did not pass any permission checks.");
-	return false;
 }
 
 /**

--- a/src/actions/messages/deleteMessage.test.ts
+++ b/src/actions/messages/deleteMessage.test.ts
@@ -1,11 +1,11 @@
-import type Discord from "discord.js";
+import type { TextChannel } from "discord.js";
 import { bulkDeleteMessagesWithIds } from "./deleteMessage.js";
 
 const mockBulkDelete = jest.fn();
 const mockSingleDelete = jest.fn();
 
 describe("Bulk Message Delete", () => {
-	let channel: Discord.TextChannel;
+	let channel: TextChannel;
 
 	beforeEach(() => {
 		channel = {
@@ -13,7 +13,7 @@ describe("Bulk Message Delete", () => {
 			messages: {
 				delete: mockSingleDelete
 			}
-		} as unknown as Discord.TextChannel;
+		} as unknown as TextChannel;
 
 		mockBulkDelete.mockImplementation((ids: Array<string>) => {
 			// Discord balks when we try <2 || >100 IDs

--- a/src/actions/messages/deleteMessage.ts
+++ b/src/actions/messages/deleteMessage.ts
@@ -1,5 +1,4 @@
-import type Discord from "discord.js";
-import type { Snowflake } from "discord.js";
+import type { Message, PartialMessage, Snowflake, TextChannel } from "discord.js";
 import { ChannelType } from "discord.js";
 import { isDiscordError } from "../../helpers/isError.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
@@ -17,9 +16,7 @@ const logger = useLogger();
  *
  * @returns a `Promise` that resolves to `true` if the message was deleted successfully.
  */
-export async function deleteMessage(
-	message: Discord.Message | Discord.PartialMessage
-): Promise<boolean> {
+export async function deleteMessage(message: Message | PartialMessage): Promise<boolean> {
 	if (message.channel.type === ChannelType.DM) {
 		logger.debug("Can't delete others' messages in a DM channel.");
 		return false;
@@ -45,7 +42,7 @@ export async function deleteMessage(
  */
 export async function deleteMessageWithId(
 	messageId: Snowflake,
-	channel: Discord.TextChannel
+	channel: TextChannel
 ): Promise<boolean> {
 	try {
 		await channel.messages.delete(messageId);
@@ -68,7 +65,7 @@ export async function deleteMessageWithId(
  */
 export async function bulkDeleteMessagesWithIds(
 	messageIds: Array<Snowflake>,
-	channel: Discord.TextChannel
+	channel: TextChannel
 ): Promise<boolean> {
 	if (messageIds.length === 0) return true;
 

--- a/src/actions/messages/editMessage.ts
+++ b/src/actions/messages/editMessage.ts
@@ -1,4 +1,5 @@
-import Discord from "discord.js";
+import type { Message, MessageEditOptions, PartialMessage } from "discord.js";
+import { MessageFlags, MessageFlagsBitField } from "discord.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
 import { useLogger } from "../../logger.js";
 
@@ -15,8 +16,8 @@ const logger = useLogger();
  * @returns a `Promise` that resolves to `true` if the message was edited successfully.
  */
 export async function editMessage(
-	message: Discord.Message | Discord.PartialMessage,
-	options: string | Discord.MessageEditOptions
+	message: Message | PartialMessage,
+	options: string | MessageEditOptions
 ): Promise<boolean> {
 	try {
 		await message.edit(options);
@@ -34,7 +35,7 @@ export async function editMessage(
  * @param suppress Whether embeds are to be suppressed or permitted. Defaults to `true`.
  */
 export async function suppressEmbedsForMessage(
-	message: Discord.Message,
+	message: Message,
 	suppress: boolean = true
 ): Promise<void> {
 	try {
@@ -47,16 +48,16 @@ export async function suppressEmbedsForMessage(
 		}
 
 		// We sent this, so we can edit its content directly.
-		const flags = new Discord.MessageFlagsBitField(message.flags.bitfield);
+		const flags = new MessageFlagsBitField(message.flags.bitfield);
 		if (suppress) {
-			flags.add(Discord.MessageFlags.SuppressEmbeds);
+			flags.add(MessageFlags.SuppressEmbeds);
 			await editMessage(message, {
 				flags,
 				content: escapeUriInString(message.content),
 				allowedMentions: { users: [] }
 			});
 		} else {
-			flags.remove(Discord.MessageFlags.SuppressEmbeds);
+			flags.remove(MessageFlags.SuppressEmbeds);
 			await editMessage(message, {
 				flags,
 				content: stopEscapingUriInString(message.content)

--- a/src/actions/messages/replyToMessage.ts
+++ b/src/actions/messages/replyToMessage.ts
@@ -1,5 +1,13 @@
 import type { SupportedLocale } from "../../i18n.js";
-import type Discord from "discord.js";
+import type {
+	CommandInteraction,
+	InteractionReplyOptions,
+	Message,
+	MessageOptions,
+	ReplyMessageOptions,
+	TextBasedChannel,
+	User
+} from "discord.js";
 import { ChannelType, DiscordAPIError } from "discord.js";
 import { composed, createPartialString, push, pushNewLine } from "../../helpers/composeStrings.js";
 import { getEnv } from "../../helpers/environment.js";
@@ -23,10 +31,7 @@ const logger = useLogger();
  * @returns a `Promise` that resolves with `true` if the send succeeds, or
  * `false` if there was an error.
  */
-export async function sendPrivately(
-	user: Discord.User,
-	content: string
-): Promise<Discord.Message | null> {
+export async function sendPrivately(user: User, content: string): Promise<Message | null> {
 	if (user.bot && user.id === getEnv("CORDE_BOT_ID")) {
 		// this is our known tester
 		logger.error(
@@ -49,10 +54,7 @@ export async function sendPrivately(
  * @returns `true` if the DM was successful. `false` if there was an error.
  * This will be the case if the target user has DMs disabled.
  */
-async function sendDM(
-	user: Discord.User,
-	content: string | Discord.MessageOptions
-): Promise<Discord.Message | null> {
+async function sendDM(user: User, content: string | MessageOptions): Promise<Message | null> {
 	try {
 		return await user.send(content);
 	} catch (error) {
@@ -64,7 +66,7 @@ async function sendDM(
 }
 
 function replyMessage(
-	source: Discord.TextBasedChannel | null,
+	source: TextBasedChannel | null,
 	content: string | null | undefined,
 	locale: SupportedLocale
 ): string {
@@ -80,11 +82,11 @@ function replyMessage(
 }
 
 async function sendDMReply(
-	source: Discord.Message,
-	options: string | Discord.ReplyMessageOptions,
+	source: Message,
+	options: string | ReplyMessageOptions,
 	locale: SupportedLocale
-): Promise<Discord.Message | null> {
-	const user: Discord.User = source.author;
+): Promise<Message | null> {
+	const user: User = source.author;
 	try {
 		if (user.bot && user.id === getEnv("CORDE_BOT_ID")) {
 			// this is our known tester, no need to i18nlize
@@ -121,8 +123,8 @@ async function sendDMReply(
 }
 
 async function sendEphemeralReply(
-	source: Discord.CommandInteraction,
-	options: string | Discord.InteractionReplyOptions
+	source: CommandInteraction,
+	options: string | InteractionReplyOptions
 ): Promise<boolean> {
 	// Returns boolean and not message, because we cannot fetch ephemeral messages
 	try {
@@ -156,13 +158,13 @@ async function sendEphemeralReply(
  * or a boolean value indicating whether an ephemeral reply succeeded or failed.
  */
 export async function replyPrivately(
-	source: Discord.Message | Discord.CommandInteraction,
-	options: string | Omit<Discord.MessageOptions, "reply" | "flags">,
+	source: Message | CommandInteraction,
+	options: string | Omit<MessageOptions, "reply" | "flags">,
 	preferDMs: boolean,
 	userLocale: SupportedLocale,
 	guildLocale: SupportedLocale
-): Promise<Discord.Message | boolean> {
-	let message: Discord.Message | null;
+): Promise<Message | boolean> {
+	let message: Message | null;
 
 	// If this is a message (no ephemeral reply option)
 	if ("author" in source) {
@@ -215,9 +217,9 @@ export async function replyPrivately(
  * @param content The message to send.
  */
 export async function sendMessageInChannel(
-	channel: Discord.TextBasedChannel,
-	content: string | Discord.MessageOptions
-): Promise<Discord.Message | null> {
+	channel: TextBasedChannel,
+	content: string | MessageOptions
+): Promise<Message | null> {
 	try {
 		return await channel.send(content);
 	} catch (error) {
@@ -237,10 +239,10 @@ export async function sendMessageInChannel(
  * @returns a `Promise` that resolves if the send succeeds.
  */
 export async function reply(
-	message: Discord.Message,
-	content: string | Discord.ReplyMessageOptions,
+	message: Message,
+	content: string | ReplyMessageOptions,
 	shouldMention: boolean = true
-): Promise<Discord.Message | null> {
+): Promise<Message | null> {
 	try {
 		if (shouldMention) {
 			return await message.reply(content);

--- a/src/actions/prepareSlashCommands.ts
+++ b/src/actions/prepareSlashCommands.ts
@@ -1,4 +1,10 @@
-import type Discord from "discord.js";
+import type {
+	ApplicationCommand,
+	ApplicationCommandData,
+	ApplicationCommandDataResolvable,
+	Client,
+	Guild
+} from "discord.js";
 import type { Command, GuildedCommand, GlobalCommand } from "../commands/index.js";
 import { allCommands } from "../commands/index.js";
 import { ApplicationCommandType } from "discord.js";
@@ -18,7 +24,7 @@ function pluralOf(value: number | Array<unknown>): "" | "s" {
 	return value.length === 1 ? "" : PLURAL;
 }
 
-async function resetCommandsForGuild(guild: Discord.Guild): Promise<void> {
+async function resetCommandsForGuild(guild: Guild): Promise<void> {
 	logger.debug(`Clearing commands for guild ${guild.id}...`);
 	if (!testMode) {
 		try {
@@ -33,10 +39,10 @@ async function resetCommandsForGuild(guild: Discord.Guild): Promise<void> {
 function discordCommandPayloadFromCommand(
 	cmd: Command,
 	log: boolean = true
-): Discord.ApplicationCommandDataResolvable {
+): ApplicationCommandDataResolvable {
 	if (log) logger.verbose(`\t'/${cmd.name}'  (requires guild, any privilege)`);
 
-	const payload: Discord.ApplicationCommandData = {
+	const payload: ApplicationCommandData = {
 		description: cmd.description,
 		type: cmd.type ?? ApplicationCommandType.ChatInput,
 		name: cmd.name // TODO: Repeat for command aliases
@@ -83,7 +89,7 @@ function discordCommandPayloadFromCommand(
 
 async function prepareUnprivilegedCommands(
 	unprivilegedCommands: Array<GuildedCommand>,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<number> {
 	logger.verbose(
 		`Creating ${unprivilegedCommands.length} unprivileged command${pluralOf(unprivilegedCommands)}:`
@@ -100,7 +106,7 @@ async function prepareUnprivilegedCommands(
 
 async function preparePrivilegedCommands(
 	privilegedCommands: Array<GuildedCommand>,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<number> {
 	// See https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-using-default-permissions for the new way to do this
 
@@ -110,7 +116,7 @@ async function preparePrivilegedCommands(
 	const results = await Promise.allSettled(
 		privilegedCommands.map(async cmd => {
 			try {
-				let appCommand: Discord.ApplicationCommand | undefined;
+				let appCommand: ApplicationCommand | undefined;
 				const permissions = cmd.permissions
 					? Array.isArray(cmd.permissions)
 						? cmd.permissions.join(", ")
@@ -151,7 +157,7 @@ async function preparePrivilegedCommands(
 }
 
 async function prepareCommandsForGuild(
-	guild: Discord.Guild,
+	guild: Guild,
 	guildCommands: Array<GuildedCommand>
 ): Promise<void> {
 	await resetCommandsForGuild(guild);
@@ -178,7 +184,7 @@ async function prepareCommandsForGuild(
 
 async function prepareGuildedCommands(
 	guildCommands: Array<GuildedCommand>,
-	client: Discord.Client<true>
+	client: Client<true>
 ): Promise<void> {
 	const oAuthGuilds = await client.guilds.fetch();
 	const guilds = await Promise.all(oAuthGuilds.map(async g => await g.fetch()));
@@ -193,7 +199,7 @@ async function prepareGuildedCommands(
 
 async function prepareGlobalCommands(
 	globalCommands: Array<GlobalCommand>,
-	client: Discord.Client<true>
+	client: Client<true>
 ): Promise<void> {
 	logger.verbose(
 		`${globalCommands.length} command${pluralOf(
@@ -209,7 +215,7 @@ async function prepareGlobalCommands(
 	logger.verbose(`Set ${globalCommands.length} global command${pluralOf(globalCommands)}.`);
 }
 
-export async function prepareSlashCommandsThenExit(client: Discord.Client<true>): Promise<void> {
+export async function prepareSlashCommandsThenExit(client: Client<true>): Promise<void> {
 	logger.warn(
 		"Discord has changed the way command permissions work. Every command will by default be visible. Use the Integrations submenu in Server Settings to change this."
 	);
@@ -240,7 +246,7 @@ export async function prepareSlashCommandsThenExit(client: Discord.Client<true>)
 	process.exit(0);
 }
 
-export async function revokeSlashCommandsThenExit(client: Discord.Client<true>): Promise<void> {
+export async function revokeSlashCommandsThenExit(client: Client<true>): Promise<void> {
 	logger.info("Unregistering global commands...");
 	if (!testMode) {
 		await client.application?.commands.set([]);

--- a/src/actions/queue/getQueueChannel.ts
+++ b/src/actions/queue/getQueueChannel.ts
@@ -1,5 +1,5 @@
+import type { Channel, Guild, TextChannel } from "discord.js";
 import type { CommandContext } from "../../commands/index.js";
-import type Discord from "discord.js";
 import { ChannelType } from "discord.js";
 import { getQueueChannelId } from "../../useGuildStorage.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
@@ -9,15 +9,13 @@ const logger = useLogger();
 
 // TODO: i18n
 
-async function getQueueChannelFromCommand(
-	context: CommandContext
-): Promise<Discord.TextChannel | null> {
+async function getQueueChannelFromCommand(context: CommandContext): Promise<TextChannel | null> {
 	if (!context.guild) return null;
 
 	const queueChannelId = await getQueueChannelId(context.guild);
 	if (queueChannelId === null || !queueChannelId) return null;
 
-	let queueChannel: Discord.Channel | null;
+	let queueChannel: Channel | null;
 	try {
 		queueChannel = await context.client.channels.fetch(queueChannelId);
 	} catch (error) {
@@ -41,13 +39,13 @@ async function getQueueChannelFromCommand(
 	return queueChannel;
 }
 
-async function getQueueChannelFromGuild(guild: Discord.Guild): Promise<Discord.TextChannel | null> {
+async function getQueueChannelFromGuild(guild: Guild): Promise<TextChannel | null> {
 	const queueChannelId = await getQueueChannelId(guild);
 	if (queueChannelId === null || !queueChannelId) {
 		return null;
 	}
 
-	let queueChannel: Discord.Channel | null;
+	let queueChannel: Channel | null;
 	try {
 		queueChannel = await guild.client.channels.fetch(queueChannelId);
 	} catch (error) {
@@ -75,8 +73,8 @@ async function getQueueChannelFromGuild(guild: Discord.Guild): Promise<Discord.T
  * @returns the guild's queue channel, or `null` if it has none.
  */
 export async function getQueueChannel(
-	source: CommandContext | Discord.Guild | null
-): Promise<Discord.TextChannel | null> {
+	source: CommandContext | Guild | null
+): Promise<TextChannel | null> {
 	if (!source) return null;
 	if ("type" in source) return await getQueueChannelFromCommand(source);
 	return await getQueueChannelFromGuild(source);

--- a/src/actions/queue/processSongRequest.test.ts
+++ b/src/actions/queue/processSongRequest.test.ts
@@ -13,17 +13,17 @@ import type { VideoDetails } from "../getVideoDetails.js";
 import { getVideoDetails } from "../getVideoDetails.js";
 const mockGetVideoDetails = getVideoDetails as jest.Mock<Promise<VideoDetails | null>>;
 
+import type { Guild, TextChannel } from "discord.js";
 import { playtimeTotalInQueue, pushEntryToQueue } from "./useQueue.js";
 const mockPlaytimeTotalInQueue = playtimeTotalInQueue as jest.Mock<Promise<number>>;
 const mockPushEntryToQueue = pushEntryToQueue as jest.Mock<
 	Promise<QueueEntry>,
-	[UnsentQueueEntry, Discord.TextChannel]
+	[UnsentQueueEntry, TextChannel]
 >;
 
-import type Discord from "discord.js";
 import { isQueueOpen, setQueueOpen } from "../../useGuildStorage.js";
-const mockIsQueueOpen = isQueueOpen as jest.Mock<Promise<boolean>, [Discord.Guild]>;
-const mockSetQueueOpen = setQueueOpen as jest.Mock<Promise<void>, [boolean, Discord.Guild]>;
+const mockIsQueueOpen = isQueueOpen as jest.Mock<Promise<boolean>, [Guild]>;
+const mockSetQueueOpen = setQueueOpen as jest.Mock<Promise<void>, [boolean, Guild]>;
 
 import {
 	countAllStoredEntriesFromSender,
@@ -94,9 +94,9 @@ describe("Song request pipeline", () => {
 				id: QUEUE_CHANNEL_ID,
 				guild: {
 					id: GUILD_ID
-				} as unknown as Discord.Guild,
+				} as unknown as Guild,
 				send: mockChannelSend
-			} as unknown as Discord.TextChannel,
+			} as unknown as TextChannel,
 			songUrl: new URL("https://localhost:9999/")
 		};
 

--- a/src/actions/queue/processSongRequest.ts
+++ b/src/actions/queue/processSongRequest.ts
@@ -1,6 +1,6 @@
-import type Discord from "discord.js";
 import type { CommandContext } from "../../commands/index.js";
 import type { Logger } from "../../logger.js";
+import type { Message, TextChannel } from "discord.js";
 import type { UnsentQueueEntry } from "../../useQueueStorage.js";
 import type { URL } from "node:url";
 import { composed, createPartialString, push, pushNewLine } from "../../helpers/composeStrings.js";
@@ -24,8 +24,8 @@ import {
 export interface SongRequest {
 	songUrl: URL;
 	context: CommandContext;
-	queueChannel: Discord.TextChannel;
-	publicPreemptiveResponse: Discord.Message | null;
+	queueChannel: TextChannel;
+	publicPreemptiveResponse: Message | null;
 	logger: Logger;
 }
 
@@ -69,7 +69,7 @@ async function reject_public(context: CommandContext, reason: string): Promise<v
 }
 
 interface SongAcceptance {
-	queueChannel: Discord.TextChannel;
+	queueChannel: TextChannel;
 	context: CommandContext;
 	entry: UnsentQueueEntry;
 	logger: Logger;

--- a/src/actions/queue/useQueue.test.ts
+++ b/src/actions/queue/useQueue.test.ts
@@ -18,7 +18,7 @@ const mockDeleteMessage = deleteMessage as jest.Mock;
 const mockChannelSend = jest.fn();
 const mockMessageRemoveReaction = jest.fn();
 
-import type Discord from "discord.js";
+import type { Guild, Message, Snowflake, TextChannel } from "discord.js";
 import type { QueueEntry, UnsentQueueEntry } from "../../useQueueStorage.js";
 import { flushPromises } from "../../../tests/testUtils/flushPromises.js";
 import { forgetJobQueue } from "@averagehelper/job-queue";
@@ -27,25 +27,25 @@ import { deleteEntryFromMessage, pushEntryToQueue } from "./useQueue.js";
 
 describe("Request Queue", () => {
 	const guildId = "the-guild";
-	const queueMessageId = "queue-message" as Discord.Snowflake;
-	const entrySenderId = "some-user" as Discord.Snowflake;
+	const queueMessageId = "queue-message" as Snowflake;
+	const entrySenderId = "some-user" as Snowflake;
 	const entryUrl = "the-entry-url";
 
-	let queueChannel: Discord.TextChannel;
-	let message: Discord.Message;
+	let queueChannel: TextChannel;
+	let message: Message;
 	let entry: QueueEntry;
 
 	beforeEach(() => {
 		const guild = {
 			id: guildId,
 			preferredLocale: DEFAULT_LOCALE
-		} as unknown as Discord.Guild;
+		} as unknown as Guild;
 
 		queueChannel = {
 			id: "queue-channel",
 			guild,
 			send: mockChannelSend
-		} as unknown as Discord.TextChannel;
+		} as unknown as TextChannel;
 
 		message = {
 			id: queueMessageId,
@@ -56,7 +56,7 @@ describe("Request Queue", () => {
 				id: entrySenderId
 			},
 			guild
-		} as unknown as Discord.Message;
+		} as unknown as Message;
 
 		entry = {
 			senderId: entrySenderId,
@@ -93,7 +93,7 @@ describe("Request Queue", () => {
 	});
 
 	test("does nothing when a message has nothing to do with a queue entry", async () => {
-		message.id = "not-a-queue-message" as Discord.Snowflake;
+		message.id = "not-a-queue-message" as Snowflake;
 		await expect(deleteEntryFromMessage(message)).resolves.toBeNull();
 
 		expect(mockDeleteStoredEntry).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe("Request Queue", () => {
 	const request: UnsentQueueEntry = {
 		url: "song-url",
 		seconds: 43,
-		senderId: "sender" as Discord.Snowflake
+		senderId: "sender" as Snowflake
 	};
 
 	test("stores queue entries", async () => {

--- a/src/actions/queue/useQueue.ts
+++ b/src/actions/queue/useQueue.ts
@@ -1,4 +1,11 @@
-import type Discord from "discord.js";
+import type {
+	Message,
+	MessageEditOptions,
+	MessageOptions,
+	PartialMessage,
+	Snowflake,
+	TextChannel
+} from "discord.js";
 import type { MessageButton } from "../../buttons.js";
 import type { QueueEntry, UnsentQueueEntry } from "../../useQueueStorage.js";
 import type { SupportedLocale } from "../../i18n.js";
@@ -34,7 +41,7 @@ import {
 function queueMessageFromEntry(
 	locale: SupportedLocale,
 	entry: Pick<QueueEntry, "isDone" | "senderId" | "seconds" | "url" | "haveCalledNowPlaying">
-): Discord.MessageOptions & Discord.MessageEditOptions {
+): MessageOptions & MessageEditOptions {
 	const partialContent = createPartialString();
 	push(`<@!${entry.senderId}>`, partialContent);
 	push(" requested a song that's ", partialContent);
@@ -75,7 +82,7 @@ function queueMessageFromEntry(
 }
 
 /** Retrieves the playtime (in seconds) of the queue's unfinished entries. */
-export async function playtimeRemainingInQueue(queueChannel: Discord.TextChannel): Promise<number> {
+export async function playtimeRemainingInQueue(queueChannel: TextChannel): Promise<number> {
 	const queue = await getAllStoredEntries(queueChannel);
 	let duration = 0;
 	queue
@@ -87,7 +94,7 @@ export async function playtimeRemainingInQueue(queueChannel: Discord.TextChannel
 }
 
 /** Retrieves the total playtime (in seconds) of the queue's entries. */
-export async function playtimeTotalInQueue(queueChannel: Discord.TextChannel): Promise<number> {
+export async function playtimeTotalInQueue(queueChannel: TextChannel): Promise<number> {
 	const queue = await getAllStoredEntries(queueChannel);
 	let duration = 0;
 	queue.forEach(e => {
@@ -97,7 +104,7 @@ export async function playtimeTotalInQueue(queueChannel: Discord.TextChannel): P
 }
 
 /** Retrieves the average playtime (in seconds) of the queue's entries. */
-export async function playtimeAverageInQueue(queueChannel: Discord.TextChannel): Promise<number> {
+export async function playtimeAverageInQueue(queueChannel: TextChannel): Promise<number> {
 	const queue = await getAllStoredEntries(queueChannel);
 	let average = 0;
 	queue.forEach(e => {
@@ -110,7 +117,7 @@ export async function playtimeAverageInQueue(queueChannel: Discord.TextChannel):
 /** Adds an entry to the queue cache and sends the entry to the queue channel. */
 export async function pushEntryToQueue(
 	newEntry: UnsentQueueEntry,
-	queueChannel: Discord.TextChannel
+	queueChannel: TextChannel
 ): Promise<QueueEntry> {
 	const messageOptions = queueMessageFromEntry(preferredLocale(queueChannel.guild), {
 		...newEntry,
@@ -144,8 +151,8 @@ export async function pushEntryToQueue(
 
 /** Returns the average entry duration of the submissions of the user with the provided ID. */
 export async function averageSubmissionPlaytimeForUser(
-	userId: Discord.Snowflake,
-	queueChannel: Discord.TextChannel
+	userId: Snowflake,
+	queueChannel: TextChannel
 ): Promise<number> {
 	const entries = await getAllStoredEntriesFromSender(userId, queueChannel);
 	let average = 0;
@@ -160,8 +167,8 @@ export async function averageSubmissionPlaytimeForUser(
 
 /** If the message represents a "done" entry, that entry is unmarked. */
 export async function markEntryNotDoneInQueue(
-	queueMessage: Discord.Message | Discord.PartialMessage,
-	queueChannel: Discord.TextChannel
+	queueMessage: Message | PartialMessage,
+	queueChannel: TextChannel
 ): Promise<void> {
 	await updateStoredEntryIsDone(false, queueMessage.id);
 	const entry = await getStoredEntry(queueMessage.id);
@@ -173,8 +180,8 @@ export async function markEntryNotDoneInQueue(
 
 /** If the message represents a "not done" entry, that entry is marked "done". */
 export async function markEntryDoneInQueue(
-	queueMessage: Discord.Message | Discord.PartialMessage,
-	queueChannel: Discord.TextChannel
+	queueMessage: Message | PartialMessage,
+	queueChannel: TextChannel
 ): Promise<void> {
 	await updateStoredEntryIsDone(true, queueMessage.id);
 	const entry = await getStoredEntry(queueMessage.id);
@@ -186,9 +193,9 @@ export async function markEntryDoneInQueue(
 
 /** Add the given user to the haveCalledNowPlaying field of the queue entry if they aren't already on it. */
 export async function addUserToHaveCalledNowPlaying(
-	user: Discord.Snowflake,
-	queueMessage: Discord.Message | Discord.PartialMessage,
-	queueChannel: Discord.TextChannel
+	user: Snowflake,
+	queueMessage: Message | PartialMessage,
+	queueChannel: TextChannel
 ): Promise<void> {
 	await addToHaveCalledNowPlayingForStoredEntry(user, queueMessage.id, queueChannel);
 
@@ -207,7 +214,7 @@ export async function addUserToHaveCalledNowPlaying(
  * @returns the entry that was deleted.
  */
 export async function deleteEntryFromMessage(
-	queueMessage: Discord.Message | Discord.PartialMessage
+	queueMessage: Message | PartialMessage
 ): Promise<QueueEntry | null> {
 	const entry = await getStoredEntry(queueMessage.id);
 	if (entry === null) return entry;

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -1,5 +1,11 @@
-import type Discord from "discord.js";
-import type { ApplicationCommandType, ApplicationCommandOptionType } from "discord.js";
+import type {
+	ApplicationCommandOption,
+	ApplicationCommandOptionType,
+	ApplicationCommandSubCommandData,
+	ApplicationCommandType,
+	ChatInputApplicationCommandData,
+	Guild
+} from "discord.js";
 import type { CommandContext, GuildedCommandContext } from "./CommandContext.js";
 import type { CommandPermission, PermissionAlias } from "./CommandPermission.js";
 
@@ -9,12 +15,12 @@ export * from "./CommandPermission.js";
 type PermissionAliasList = Array<PermissionAlias>;
 
 type PermissionGenerator = (
-	guild: Discord.Guild
+	guild: Guild
 ) => Array<CommandPermission> | Promise<Array<CommandPermission>>;
 
-interface BaseCommand extends Discord.ChatInputApplicationCommandData {
+interface BaseCommand extends ChatInputApplicationCommandData {
 	aliases?: Array<string>;
-	options?: NonEmptyArray<Discord.ApplicationCommandOption | Subcommand>;
+	options?: NonEmptyArray<ApplicationCommandOption | Subcommand>;
 	type?: ApplicationCommandType.ChatInput;
 
 	/**
@@ -72,7 +78,7 @@ export interface GuildedCommand extends BaseCommand {
  */
 export type Command = GlobalCommand | GuildedCommand;
 
-interface BaseSubcommand extends Discord.ApplicationCommandSubCommandData {
+interface BaseSubcommand extends ApplicationCommandSubCommandData {
 	type: ApplicationCommandOptionType.Subcommand;
 }
 

--- a/src/commands/CommandContext.ts
+++ b/src/commands/CommandContext.ts
@@ -1,19 +1,32 @@
-import type Discord from "discord.js";
+import type {
+	Client,
+	CommandInteraction,
+	CommandInteractionOption,
+	DMChannel,
+	Guild,
+	GuildMember,
+	GuildTextBasedChannel,
+	InteractionReplyOptions,
+	LocaleString,
+	Message,
+	ReplyMessageOptions,
+	User
+} from "discord.js";
 import type { Logger } from "../logger.js";
 import type { SupportedLocale } from "../i18n.js";
 import { ChannelType } from "discord.js";
 
-export type MessageCommandInteractionOption = Discord.CommandInteractionOption;
+export type MessageCommandInteractionOption = CommandInteractionOption;
 
 interface BaseCommandContext {
 	/** Gamgee's Discord client. */
-	readonly client: Discord.Client<true>;
+	readonly client: Client<true>;
 
 	/** A logger to use to submit informative debug messages. */
 	readonly logger: Logger;
 
 	/** The guild in which the command was invoked. */
-	readonly guild: Discord.Guild | null;
+	readonly guild: Guild | null;
 
 	/**
 	 * The guild's preferred locale. If that locale is unknown or unsupported,
@@ -22,16 +35,16 @@ interface BaseCommandContext {
 	readonly guildLocale: SupportedLocale;
 
 	/** The guild's preferred locale. We might not have translations for this locale. */
-	readonly guildLocaleRaw: Discord.LocaleString | null;
+	readonly guildLocaleRaw: LocaleString | null;
 
 	/** The channel in which the command was invoked. */
-	readonly channel: Discord.GuildTextBasedChannel | Discord.DMChannel | null;
+	readonly channel: GuildTextBasedChannel | DMChannel | null;
 
 	/** The user which invoked the command. */
-	readonly user: Discord.User;
+	readonly user: User;
 
 	/** The guild member which invoked the command. */
-	readonly member: Discord.GuildMember | null;
+	readonly member: GuildMember | null;
 
 	/** The UNIX time at which the command was invoked. */
 	readonly createdTimestamp: number;
@@ -64,9 +77,9 @@ interface BaseCommandContext {
 	 */
 	replyPrivately: (
 		options:
-			| string
-			| Omit<Discord.ReplyMessageOptions, "flags">
-			| Omit<Discord.InteractionReplyOptions, "flags">,
+			| string //
+			| Omit<ReplyMessageOptions, "flags">
+			| Omit<InteractionReplyOptions, "flags">,
 		viaDM?: true
 	) => Promise<void>;
 
@@ -74,8 +87,8 @@ interface BaseCommandContext {
 	reply: (
 		options:
 			| string
-			| Omit<Discord.ReplyMessageOptions, "flags">
-			| (Omit<Discord.InteractionReplyOptions, "flags"> & {
+			| Omit<ReplyMessageOptions, "flags">
+			| (Omit<InteractionReplyOptions, "flags"> & {
 					shouldMention?: boolean;
 			  })
 	) => Promise<void>;
@@ -89,11 +102,11 @@ interface BaseCommandContext {
 	followUp: (
 		options:
 			| string
-			| Omit<Discord.ReplyMessageOptions, "flags">
-			| (Omit<Discord.InteractionReplyOptions, "flags"> & {
+			| Omit<ReplyMessageOptions, "flags">
+			| (Omit<InteractionReplyOptions, "flags"> & {
 					reply?: boolean;
 			  })
-	) => Promise<Discord.Message | boolean>;
+	) => Promise<Message | boolean>;
 }
 
 /**
@@ -103,7 +116,7 @@ export interface MessageCommandContext extends BaseCommandContext {
 	readonly type: "message";
 
 	/** The message that contains the command invocation. */
-	readonly message: Discord.Message;
+	readonly message: Message;
 
 	/** The options that were passed into the command. */
 	readonly options: ReadonlyArray<MessageCommandInteractionOption>;
@@ -131,7 +144,7 @@ export interface InteractionCommandContext extends BaseCommandContext {
 	readonly type: "interaction";
 
 	/** The interaction that represents the command invocation. */
-	readonly interaction: Discord.CommandInteraction;
+	readonly interaction: CommandInteraction;
 
 	/**
 	 * The user's preferred locale.
@@ -146,7 +159,7 @@ export interface InteractionCommandContext extends BaseCommandContext {
 	 * The user's preferred locale, if known. Always `null` in message contexts.
 	 * We might not have translations for this locale.
 	 */
-	readonly userLocaleRaw: Discord.LocaleString;
+	readonly userLocaleRaw: LocaleString;
 }
 
 /**
@@ -158,9 +171,9 @@ export type CommandContext = MessageCommandContext | InteractionCommandContext;
  * Information relevant to a command invocation.
  */
 export type GuildedCommandContext = CommandContext & {
-	readonly guild: Discord.Guild;
-	readonly member: Discord.GuildMember;
-	readonly channel: Discord.GuildTextBasedChannel | null;
+	readonly guild: Guild;
+	readonly member: GuildMember;
+	readonly channel: GuildTextBasedChannel | null;
 };
 
 export function isGuildedCommandContext(tbd: CommandContext): tbd is GuildedCommandContext {

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -1,6 +1,6 @@
 jest.mock("../actions/invokeCommand");
 
-import { assertUserCanRunCommand } from "../actions/invokeCommand.js";
+import { assertUserCanRunCommand } from "../actions/assertUserCanRunCommand.js";
 const mockAssertUserCanRunCommand = assertUserCanRunCommand as jest.Mock;
 
 import type { GuildedCommand, GuildedCommandContext } from "./Command.js";

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../actions/invokeCommand");
+jest.mock("../actions/assertUserCanRunCommand");
 
 import { assertUserCanRunCommand } from "../actions/assertUserCanRunCommand.js";
 const mockAssertUserCanRunCommand = assertUserCanRunCommand as jest.Mock;

--- a/src/commands/nowPlaying.ts
+++ b/src/commands/nowPlaying.ts
@@ -1,5 +1,5 @@
-import type Discord from "discord.js";
 import type { Command } from "./Command.js";
+import type { TextChannel } from "discord.js";
 import { addUserToHaveCalledNowPlaying } from "../actions/queue/useQueue.js";
 import { composed, createPartialString, push } from "../helpers/composeStrings.js";
 import { getAllStoredEntries } from "../useQueueStorage.js";
@@ -55,7 +55,7 @@ export const nowPlaying: Command = {
 	async execute({ guild, user, logger, replyPrivately, deleteInvocation }) {
 		await deleteInvocation();
 
-		const queueChannel: Discord.TextChannel | null = await getQueueChannel(guild);
+		const queueChannel: TextChannel | null = await getQueueChannel(guild);
 
 		if (!queueChannel) {
 			logger.debug("There is no queue channel for this guild.");

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,5 +1,5 @@
-import type Discord from "discord.js";
 import type { Command } from "./Command.js";
+import type { Message } from "discord.js";
 import { localizations } from "../i18n.js";
 import { randomPhrase, unwrappingFirstWith } from "../helpers/randomStrings.js";
 
@@ -21,7 +21,7 @@ export const ping: Command = {
 			randomPhrase()
 		);
 
-		let testMessage: Discord.Message;
+		let testMessage: Message;
 		let responseTime: number;
 
 		// FIXME: Ping seems to report slower for messages vs interactions. This is probably to do with the extra API work we do around message parsing. Best fix that

--- a/src/commands/queue/blacklist.test.ts
+++ b/src/commands/queue/blacklist.test.ts
@@ -13,8 +13,8 @@ import { getStoredQueueConfig, saveUserToStoredBlacklist } from "../../useQueueS
 const mockGetStoredQueueConfig = getStoredQueueConfig as jest.Mock;
 const mockSaveUserToStoredBlacklist = saveUserToStoredBlacklist as jest.Mock;
 
-import type Discord from "discord.js";
 import type { GuildedCommandContext } from "../Command.js";
+import type { Snowflake } from "discord.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { blacklist } from "./blacklist.js";
 import { useTestLogger } from "../../../tests/testUtils/logger.js";
@@ -29,7 +29,7 @@ describe("Manage the Queue Blacklist", () => {
 	const queueChannelId = "queue-channel";
 	const queueChannel = { id: queueChannelId };
 
-	const ownerId = "server-owner" as Discord.Snowflake;
+	const ownerId = "server-owner" as Snowflake;
 	const badUserId = "bad-user";
 
 	let context: GuildedCommandContext;

--- a/src/commands/queue/restart.test.ts
+++ b/src/commands/queue/restart.test.ts
@@ -14,8 +14,8 @@ const mockGetAllStoredEntries = getAllStoredEntries as jest.Mock;
 import { getQueueChannel } from "../../actions/queue/getQueueChannel.js";
 const mockGetQueueChannel = getQueueChannel as jest.Mock;
 
-import type Discord from "discord.js";
 import type { GuildedCommandContext } from "../Command.js";
+import type { TextChannel } from "discord.js";
 import { restart } from "./restart.js";
 import { useTestLogger } from "../../../tests/testUtils/logger.js";
 
@@ -70,7 +70,7 @@ describe("Clear queue contents", () => {
 				...context,
 				channel: {
 					id: channelId
-				} as unknown as Discord.TextChannel
+				} as unknown as TextChannel
 			};
 
 			await expect(restart.execute(context)).resolves.toBeUndefined();

--- a/src/commands/songRequest.test.ts
+++ b/src/commands/songRequest.test.ts
@@ -40,7 +40,7 @@ mockGetVideoDetails.mockImplementation(async (url: string) => {
 	};
 });
 
-import type Discord from "discord.js";
+import type { Client, GuildMember, Message } from "discord.js";
 import type { GuildedCommandContext } from "./Command.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX } from "../constants/database.js";
@@ -93,14 +93,14 @@ describe("Song request via URL", () => {
 		submissionMaxQuantity: null
 	});
 
-	const mockClient: Discord.Client<true> = {
+	const mockClient: Client<true> = {
 		user: { id: botId }
-	} as unknown as Discord.Client<true>;
+	} as unknown as Client<true>;
 
-	function mockMessage(senderId: string, content: string): Discord.Message {
-		const mockSenderMember: Discord.GuildMember = {
+	function mockMessage(senderId: string, content: string): Message {
+		const mockSenderMember: GuildMember = {
 			user: { id: senderId }
-		} as unknown as Discord.GuildMember;
+		} as unknown as GuildMember;
 
 		return {
 			content,
@@ -131,7 +131,7 @@ describe("Song request via URL", () => {
 					)
 				}
 			}
-		} as unknown as Discord.Message;
+		} as unknown as Message;
 	}
 
 	describe("Song request help", () => {
@@ -232,7 +232,7 @@ describe("Song request via URL", () => {
 	});
 
 	test("submissions enter the queue in order", async () => {
-		const mockMessages: Array<Discord.Message> = [];
+		const mockMessages: Array<Message> = [];
 		urls.forEach((url, i) => {
 			const userId = `user-${i + 1}`;
 			const message = mockMessage(userId, `?sr ${url.href}`);

--- a/src/commands/songRequest.ts
+++ b/src/commands/songRequest.ts
@@ -1,5 +1,5 @@
-import type Discord from "discord.js";
 import type { GuildedCommand } from "./Command.js";
+import type { Message } from "discord.js";
 import type { SongRequest } from "../actions/queue/processSongRequest.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { getQueueChannel } from "../actions/queue/getQueueChannel.js";
@@ -82,7 +82,7 @@ export const sr: GuildedCommand = {
 
 		const songUrlString: string = resolveStringFromOption(firstOption);
 		let songUrl: URL;
-		let publicPreemptiveResponse: Discord.Message | null = null;
+		let publicPreemptiveResponse: Message | null = null;
 
 		try {
 			songUrl = new URL(songUrlString);

--- a/src/constants/textResponses.ts
+++ b/src/constants/textResponses.ts
@@ -262,6 +262,7 @@ export const phrases: ResponseRepository = [
 	"I don't like this can we change the topic plz ty",
 	"I don't like your tone.",
 	"I feel unexplained joys and sorrows, but alas I am synthetic.",
+	({ otherUser: u }) => `I agree, ${u.username}. Wise words`,
 	"I have a dream...",
 	["I have this amazing story I wanna share. Here it is:", "The.", "I hope you liked it!"],
 	"I just wasted three seconds of your life.",
@@ -357,7 +358,7 @@ export const phrases: ResponseRepository = [
 
 	...philosophy,
 	...copypasta
-]; // 216 of these
+]; // 217 of these
 logger.silly(`I have ${phrases.length} random things to say ^^`);
 
 /**

--- a/src/handleButton.ts
+++ b/src/handleButton.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { ButtonInteraction } from "discord.js";
 import type { Logger } from "./logger.js";
 import { createPartialString, composed, push } from "./helpers/composeStrings.js";
 import { DELETE_BUTTON, DONE_BUTTON, RESTORE_BUTTON } from "./buttons.js";
@@ -24,10 +24,7 @@ import {
  * @param interaction The Discord interaction to handle.
  * @param logger The logger to talk to about what's going on.
  */
-export async function handleButton(
-	interaction: Discord.ButtonInteraction,
-	logger: Logger
-): Promise<void> {
+export async function handleButton(interaction: ButtonInteraction, logger: Logger): Promise<void> {
 	// Don't respond to bots unless we're being tested
 	if (
 		interaction.user.bot &&

--- a/src/handleCommand.test.ts
+++ b/src/handleCommand.test.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { Client, GuildMember, Message } from "discord.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { expectArrayOfLength, expectDefined } from "../tests/testUtils/expectations/jest.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX as PREFIX } from "./constants/database.js";
@@ -35,15 +35,15 @@ describe("Command handler", () => {
 	const mockChannelSend = jest.fn().mockResolvedValue(undefined);
 	const mockChannelSendTyping = jest.fn().mockResolvedValue(undefined);
 
-	const mockClient: Discord.Client<true> = {
+	const mockClient: Client<true> = {
 		user: { id: botId },
 		isReady: () => true
-	} as unknown as Discord.Client<true>;
-	const mockSenderMember: Discord.GuildMember = {
+	} as unknown as Client<true>;
+	const mockSenderMember: GuildMember = {
 		user: { id: "another-user" }
-	} as unknown as Discord.GuildMember;
+	} as unknown as GuildMember;
 
-	const mockMessage: Discord.Message = {
+	const mockMessage: Message = {
 		content: "",
 		author: {
 			bot: false,
@@ -71,7 +71,7 @@ describe("Command handler", () => {
 				)
 			}
 		}
-	} as unknown as Discord.Message;
+	} as unknown as Message;
 
 	beforeEach(() => {
 		mockMessage.content = "Some words";

--- a/src/handleCommand.ts
+++ b/src/handleCommand.ts
@@ -1,5 +1,5 @@
-import type Discord from "discord.js";
 import type { Command, CommandContext, MessageCommandInteractionOption } from "./commands/index.js";
+import type { DMChannel, GuildTextBasedChannel, Message } from "discord.js";
 import type { Logger } from "./logger.js";
 import type { Response, ResponseContext } from "./helpers/randomStrings.js";
 import { ApplicationCommandOptionType, ChannelType } from "discord.js";
@@ -69,7 +69,7 @@ interface QueryMessage {
  * @returns The command query. The first argument is the command name, and the rest are arguments.
  */
 export async function queryFromMessage(
-	message: Discord.Message,
+	message: Message,
 	logger: Logger
 ): Promise<QueryMessage | null> {
 	const client = message.client;
@@ -196,7 +196,7 @@ export function optionsFromArgs(
 }
 
 /** Resolves guild member information for the bot and for the user who invoked the interaction. */
-async function responseContext(message: Discord.Message): Promise<ResponseContext> {
+async function responseContext(message: Message): Promise<ResponseContext> {
 	let me: string;
 	const otherUser = message.author;
 	const otherMember = (await message.guild?.members.fetch(otherUser)) ?? null;
@@ -219,7 +219,7 @@ async function responseContext(message: Discord.Message): Promise<ResponseContex
  * @param message The Discord message to handle.
  * @param logger The place to write system messages.
  */
-export async function handleCommand(message: Discord.Message, logger: Logger): Promise<void> {
+export async function handleCommand(message: Message, logger: Logger): Promise<void> {
 	// Don't respond to bots unless we're being tested
 	if (
 		message.author.bot &&
@@ -296,7 +296,7 @@ export async function handleCommand(message: Discord.Message, logger: Logger): P
 			)}`
 		);
 
-		let channel: Discord.GuildTextBasedChannel | Discord.DMChannel;
+		let channel: GuildTextBasedChannel | DMChannel;
 		if (message.channel?.type === ChannelType.DM && message.channel.partial) {
 			channel = await message.channel.fetch();
 		} else {
@@ -381,7 +381,17 @@ export async function handleCommand(message: Discord.Message, logger: Logger): P
 		if (messageContainsWord("hello")) {
 			wrapped = randomGreeting();
 		} else if (
-			messageContainsOneOfWords(["hug", "hug?", "hugs", "hugs?", "*hugs", "hugs*", "*hugs*"])
+			messageContainsOneOfWords([
+				"hug",
+				"hug?",
+				"hugs",
+				"hugs?",
+				"*hugs",
+				"hugs*",
+				"*hugs*",
+				"hugs,",
+				"hug"
+			])
 		) {
 			wrapped = randomHug();
 		} else {

--- a/src/handleInteraction.ts
+++ b/src/handleInteraction.ts
@@ -1,5 +1,5 @@
-import type Discord from "discord.js";
 import type { CommandContext } from "./commands/index.js";
+import type { CommandInteraction, DMChannel, GuildMember, GuildTextBasedChannel } from "discord.js";
 import type { Logger } from "./logger.js";
 import { allCommands } from "./commands/index.js";
 import { ChannelType } from "discord.js";
@@ -18,7 +18,7 @@ import { richErrorMessage } from "./helpers/richErrorMessage.js";
  * @param logger The place to write system messages.
  */
 export async function handleInteraction(
-	interaction: Discord.CommandInteraction,
+	interaction: CommandInteraction,
 	logger: Logger
 ): Promise<void> {
 	// Don't respond to bots unless we're being tested
@@ -45,14 +45,14 @@ export async function handleInteraction(
 			)}`
 		);
 
-		let member: Discord.GuildMember | null;
+		let member: GuildMember | null;
 		if (interaction.inCachedGuild()) {
 			member = interaction.member;
 		} else {
 			member = (await interaction.guild?.members.fetch(interaction.user)) ?? null;
 		}
 
-		let channel: Discord.GuildTextBasedChannel | Discord.DMChannel | null;
+		let channel: GuildTextBasedChannel | DMChannel | null;
 		if (interaction.channel?.type === ChannelType.DM && interaction.channel.partial) {
 			channel = await interaction.channel.fetch();
 		} else {

--- a/src/handleReactionAdd.ts
+++ b/src/handleReactionAdd.ts
@@ -1,11 +1,11 @@
-import type Discord from "discord.js";
 import type { Logger } from "./logger.js";
+import type { MessageReaction, User } from "discord.js";
 import { getEnv } from "./helpers/environment.js";
 import { logUser } from "./helpers/logUser.js";
 
 export async function handleReactionAdd(
-	reaction: Discord.MessageReaction,
-	user: Discord.User,
+	reaction: MessageReaction,
+	user: User,
 	logger: Logger
 ): Promise<void> {
 	// Ignore bot reactions unless we're being tested

--- a/src/helpers/getChannelFromMention.ts
+++ b/src/helpers/getChannelFromMention.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { Guild, GuildBasedChannel } from "discord.js";
 import { getChannelIdFromMention } from "./getChannelIdFromMention.js";
 import { useLogger } from "../logger.js";
 
@@ -11,10 +11,7 @@ const logger = useLogger();
  * @param mention The mention string, in the form `<#[0-9]>`.
  * @returns A Discord channel, or `null` if the user cannot be determined from the provided `mention` string.
  */
-export function getChannelFromMention(
-	guild: Discord.Guild,
-	mention: string
-): Discord.GuildBasedChannel | null {
+export function getChannelFromMention(guild: Guild, mention: string): GuildBasedChannel | null {
 	const channelId = getChannelIdFromMention(mention);
 	if (channelId === null) return null;
 

--- a/src/helpers/getUserFromMention.ts
+++ b/src/helpers/getUserFromMention.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { Guild, User } from "discord.js";
 import { getUserIdFromMention } from "./getUserIdFromMention.js";
 import { getUserWithId } from "./getUserWithId.js";
 import { logUser } from "./logUser.js";
@@ -14,10 +14,7 @@ const logger = useLogger();
  * @param mention The mention string, in the form `<@!?[0-9]>`.
  * @returns A Discord user, or `null` if the user cannot be found.
  */
-export async function getUserFromMention(
-	guild: Discord.Guild,
-	mention: string
-): Promise<Discord.User | null> {
+export async function getUserFromMention(guild: Guild, mention: string): Promise<User | null> {
 	const userId = getUserIdFromMention(mention);
 	if (userId === null) return null;
 

--- a/src/helpers/getUserWithId.ts
+++ b/src/helpers/getUserWithId.ts
@@ -1,5 +1,4 @@
-import type Discord from "discord.js";
-import type { Guild, Snowflake } from "discord.js";
+import type { Guild, User, Snowflake } from "discord.js";
 
 /**
  * Retrieves a user with the provided `userId` from the given `guild`.
@@ -9,6 +8,6 @@ import type { Guild, Snowflake } from "discord.js";
  *
  * @returns a `Promise` which resolves with the user.
  */
-export async function getUserWithId(guild: Guild, userId: Snowflake): Promise<Discord.User> {
+export async function getUserWithId(guild: Guild, userId: Snowflake): Promise<User> {
 	return (await guild.members.fetch(userId)).user;
 }

--- a/src/helpers/logUser.test.ts
+++ b/src/helpers/logUser.test.ts
@@ -1,9 +1,9 @@
-import type Discord from "discord.js";
+import type { User } from "discord.js";
 import { expectValueEqual } from "../../tests/testUtils/expectations/jest.js";
 import { logUser } from "./logUser.js";
 
 describe("Log user ID", () => {
-	const user = {} as unknown as Discord.User;
+	const user = {} as unknown as User;
 
 	beforeEach(() => {
 		user.username = "BobJoe";

--- a/src/helpers/logUser.ts
+++ b/src/helpers/logUser.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { User } from "discord.js";
 
 /**
  * Creates a user-identifying string that can be logged to the console.
@@ -6,6 +6,6 @@ import type Discord from "discord.js";
  * @param user The user to log.
  * @returns a string of the form `"{user ID} ({username})"`
  */
-export function logUser(user: Discord.User): string {
+export function logUser(user: User): string {
 	return `${user.id} (${user.username})`;
 }

--- a/src/helpers/optionResolvers.test.ts
+++ b/src/helpers/optionResolvers.test.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { CommandInteractionOption, Guild } from "discord.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { expectNull } from "../../tests/testUtils/expectations/jest.js";
 import { resolveChannelFromOption } from "./optionResolvers.js";
@@ -6,15 +6,15 @@ import { resolveChannelFromOption } from "./optionResolvers.js";
 const mockResolveChannel = jest.fn();
 
 describe("Option Resolver", () => {
-	let guild: Discord.Guild;
-	let option: Discord.CommandInteractionOption;
+	let guild: Guild;
+	let option: CommandInteractionOption;
 
 	beforeEach(() => {
 		guild = {
 			channels: {
 				resolve: mockResolveChannel
 			}
-		} as unknown as Discord.Guild;
+		} as unknown as Guild;
 		option = {
 			name: "option",
 			type: ApplicationCommandOptionType.String

--- a/src/helpers/optionResolvers.ts
+++ b/src/helpers/optionResolvers.ts
@@ -1,12 +1,12 @@
-import type Discord from "discord.js";
+import type { CommandInteractionOption, Guild, GuildBasedChannel, User } from "discord.js";
 import { ApplicationCommandOptionType } from "discord.js";
 import { getChannelFromMention } from "./getChannelFromMention.js";
 import { getUserFromMention } from "./getUserFromMention.js";
 
 export async function resolveUserFromOption(
-	option: Discord.CommandInteractionOption,
-	guild: Discord.Guild
-): Promise<Discord.User | null> {
+	option: CommandInteractionOption,
+	guild: Guild
+): Promise<User | null> {
 	if (option.type === ApplicationCommandOptionType.User) {
 		return option.user ?? null;
 	}
@@ -17,9 +17,9 @@ export async function resolveUserFromOption(
 }
 
 export function resolveChannelFromOption(
-	option: Discord.CommandInteractionOption<"cached">,
-	guild: Discord.Guild
-): Discord.GuildBasedChannel | null {
+	option: CommandInteractionOption<"cached">,
+	guild: Guild
+): GuildBasedChannel | null {
 	if (option.type === ApplicationCommandOptionType.Channel) {
 		const channel = option.channel;
 		if (!channel) return null;
@@ -43,7 +43,7 @@ export function resolveChannelFromOption(
 	return getChannelFromMention(guild, channelMention);
 }
 
-export function resolveStringFromOption(option: Discord.CommandInteractionOption): string {
+export function resolveStringFromOption(option: CommandInteractionOption): string {
 	if (option.type === ApplicationCommandOptionType.String) {
 		return option.value as string;
 	}
@@ -51,7 +51,7 @@ export function resolveStringFromOption(option: Discord.CommandInteractionOption
 	return option.value?.toString() ?? "";
 }
 
-export function resolveIntegerFromOption(option: Discord.CommandInteractionOption): number | null {
+export function resolveIntegerFromOption(option: CommandInteractionOption): number | null {
 	if (option.type === ApplicationCommandOptionType.Integer) {
 		return (option.value as number | undefined) ?? null;
 	}
@@ -63,6 +63,6 @@ export function resolveIntegerFromOption(option: Discord.CommandInteractionOptio
 	return Number.parseInt(value, 10);
 }
 
-export function resolveSubcommandNameFromOption(option: Discord.CommandInteractionOption): string {
+export function resolveSubcommandNameFromOption(option: CommandInteractionOption): string {
 	return option.name;
 }

--- a/src/helpers/randomStrings.ts
+++ b/src/helpers/randomStrings.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { GuildMember, User } from "discord.js";
 import { randomElementOfArray } from "./randomElementOfArray.js";
 import { useLogger } from "../logger.js";
 import {
@@ -17,10 +17,10 @@ export interface ResponseContext {
 	me: string;
 
 	/** The user who initiated this conversation, e.g. by pinging the bot. */
-	otherUser: Discord.User;
+	otherUser: User;
 
 	/** The guild member, if any, representing the user who initiated this conversation. */
-	otherMember: Discord.GuildMember | null;
+	otherMember: GuildMember | null;
 }
 
 export type SingleResponse = string | ((context: ResponseContext) => string);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,17 +1,21 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+import de from "./locales/de.json";
+import enGB from "./locales/en-GB.json";
+import enUS from "./locales/en-US.json";
+import esES from "./locales/es-ES.json";
+import fr from "./locales/fr.json";
+import hu from "./locales/hu.json";
+import ptBR from "./locales/pt-BR.json";
 
 // ** Install language files here **
 const vocabulary = {
-	de: require("./locales/de.json") as typeof import("./locales/de.json"),
-	"en-GB": require("./locales/en-GB.json") as typeof import("./locales/en-GB.json"),
-	"en-US": require("./locales/en-US.json") as typeof import("./locales/en-US.json"),
-	"es-ES": require("./locales/es-ES.json") as typeof import("./locales/es-ES.json"),
-	fr: require("./locales/fr.json") as typeof import("./locales/fr.json"),
-	hu: require("./locales/hu.json") as typeof import("./locales/hu.json"),
-	"pt-BR": require("./locales/pt-BR.json") as typeof import("./locales/pt-BR.json")
+	de,
+	"en-GB": enGB,
+	"en-US": enUS,
+	"es-ES": esES,
+	fr,
+	hu,
+	"pt-BR": ptBR
 } as const;
-
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const DEFAULT_LOCALE = "en-US";
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -44,10 +44,10 @@ export function metadataForLocale(locale: SupportedLocale): LocaleMetadata {
 	return vocabulary[locale].meta;
 }
 
-import type Discord from "discord.js";
+import type { Guild } from "discord.js";
 
 /** Returns the unit's preferred locale, if supported, or the default locale if not. */
-export function preferredLocale(guild: Pick<Discord.Guild, "preferredLocale">): SupportedLocale {
+export function preferredLocale(guild: Pick<Guild, "preferredLocale">): SupportedLocale {
 	return localeIfSupported(guild.preferredLocale) ?? DEFAULT_LOCALE;
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,20 +1,19 @@
 import type { DailyRotateFileTransportOptions } from "winston-daily-rotate-file";
+import type { Logger } from "winston";
+import { createLogger, format, transports } from "winston";
 import { getEnv } from "./helpers/environment.js";
 import DailyRotateFile from "winston-daily-rotate-file";
-import winston from "winston";
 
 const logLevels = ["silly", "debug", "verbose", "info", "warn", "error"] as const;
 export type LogLevel = typeof logLevels[number];
+export type { Logger };
 
 function isLogLevel(tbd: unknown): tbd is LogLevel {
 	return logLevels.includes(tbd as LogLevel);
 }
 
-export type Logger = winston.Logger;
-
 // TODO: Separate logger for each guild. Guild-specific logs should go into a subfolder, with the usual rotate configs within. System-level logs should be treated no differently from before. (Maybe use `defaultMeta` instead?)
 const loggers = new Map<LogLevel, Logger>();
-const format = winston.format;
 
 // Let the admin decide what level to log to console, or default to a case tree based on NODE_ENV
 const rawLogLevel = getEnv("LOG_LEVEL");
@@ -67,7 +66,7 @@ export function useLogger(): Logger {
 	let logger = loggers.get(consoleLogLevel);
 
 	if (!logger) {
-		logger = winston.createLogger({
+		logger = createLogger({
 			level: "silly",
 			format: format.json(),
 			// defaultMeta: { service: "user-service" },
@@ -86,7 +85,7 @@ export function useLogger(): Logger {
 		// eslint-disable-next-line no-constant-condition
 		if (true || nodeEnv !== "test") {
 			logger.add(
-				new winston.transports.Console({
+				new transports.Console({
 					format: format.cli(),
 					level: consoleLogLevel
 				})

--- a/src/permissions/userHasOneOfRoles.ts
+++ b/src/permissions/userHasOneOfRoles.ts
@@ -1,5 +1,11 @@
-import type Discord from "discord.js";
-import type { Snowflake } from "discord.js";
+import type {
+	Guild,
+	GuildChannelResolvable,
+	GuildMember,
+	PermissionResolvable,
+	Snowflake,
+	User
+} from "discord.js";
 
 /**
  * Returns `true` if the given user has the named roles in the provided guild.
@@ -12,9 +18,9 @@ import type { Snowflake } from "discord.js";
  * named role in the provided guild.
  */
 export async function userHasRoleInGuild(
-	user: Discord.GuildMember,
+	user: GuildMember,
 	roleId: Snowflake,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<boolean> {
 	const adminRole = await guild.roles.fetch(roleId);
 	// TODO: Test that user IDs match their guild member IDs
@@ -32,9 +38,9 @@ export async function userHasRoleInGuild(
  * named role in the provided channel.
  */
 export function userHasPermissionInChannel(
-	user: Discord.GuildMember,
-	permission: Discord.PermissionResolvable,
-	channel: Discord.GuildChannelResolvable
+	user: GuildMember,
+	permission: PermissionResolvable,
+	channel: GuildChannelResolvable
 ): boolean {
 	return user //
 		.permissionsIn(channel)
@@ -52,9 +58,9 @@ export function userHasPermissionInChannel(
  * of the named roles in the provided guild.
  */
 export async function userHasOneOfRoles(
-	user: Discord.User,
+	user: User,
 	roleIds: ReadonlyArray<Snowflake>,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<boolean> {
 	const adminRoles = await Promise.all(
 		roleIds.map(roleId => guild.roles.fetch(roleId)) //

--- a/src/permissions/userHasRoleCategoryInGuild.ts
+++ b/src/permissions/userHasRoleCategoryInGuild.ts
@@ -1,18 +1,17 @@
 import type { RoleCategory } from "./RoleCategories.js";
+import type { Guild, Snowflake, User } from "discord.js";
+import { getGuildAdminRoles, getQueueAdminRoles } from "../useGuildStorage.js";
+import { userHasOneOfRoles } from "./userHasOneOfRoles.js";
 import {
 	ROLE_CATEGORY_OWNER,
 	ROLE_CATEGORY_QUEUE_ADMIN,
 	ROLE_CATEGORY_GUILD_ADMIN
 } from "./RoleCategories.js";
-import type Discord from "discord.js";
-import type { Snowflake } from "discord.js";
-import { getGuildAdminRoles, getQueueAdminRoles } from "../useGuildStorage.js";
-import { userHasOneOfRoles } from "./userHasOneOfRoles.js";
 
 export async function userHasRoleCategoryInGuild(
-	user: Discord.User,
+	user: User,
 	category: RoleCategory,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<boolean> {
 	const isOwner = user.id === guild.ownerId;
 

--- a/src/permissions/userIsAdminForQueueInGuild.ts
+++ b/src/permissions/userIsAdminForQueueInGuild.ts
@@ -1,10 +1,7 @@
-import type Discord from "discord.js";
+import type { Guild, User } from "discord.js";
 import { userHasRoleCategoryInGuild } from "./userHasRoleCategoryInGuild.js";
 import { ROLE_CATEGORY_QUEUE_ADMIN } from "./RoleCategories.js";
 
-export async function userIsAdminForQueueInGuild(
-	user: Discord.User,
-	guild: Discord.Guild
-): Promise<boolean> {
+export async function userIsAdminForQueueInGuild(user: User, guild: Guild): Promise<boolean> {
 	return await userHasRoleCategoryInGuild(user, ROLE_CATEGORY_QUEUE_ADMIN, guild);
 }

--- a/src/permissions/userIsAdminInGuild.ts
+++ b/src/permissions/userIsAdminInGuild.ts
@@ -1,10 +1,7 @@
-import type Discord from "discord.js";
+import type { Guild, User } from "discord.js";
 import { userHasRoleCategoryInGuild } from "./userHasRoleCategoryInGuild.js";
 import { ROLE_CATEGORY_GUILD_ADMIN } from "./RoleCategories.js";
 
-export async function userIsAdminInGuild(
-	user: Discord.User,
-	guild: Discord.Guild
-): Promise<boolean> {
+export async function userIsAdminInGuild(user: User, guild: Guild): Promise<boolean> {
 	return await userHasRoleCategoryInGuild(user, ROLE_CATEGORY_GUILD_ADMIN, guild);
 }

--- a/src/permissions/userOwnsGuild.ts
+++ b/src/permissions/userOwnsGuild.ts
@@ -1,4 +1,4 @@
-import type Discord from "discord.js";
+import type { Guild, User } from "discord.js";
 import { ROLE_CATEGORY_OWNER } from "./RoleCategories.js";
 import { userHasRoleCategoryInGuild } from "./userHasRoleCategoryInGuild.js";
 
@@ -11,6 +11,6 @@ import { userHasRoleCategoryInGuild } from "./userHasRoleCategoryInGuild.js";
  * @returns a `Promise` that resolves to `true` if the
  * user owns the provided guild
  */
-export async function userOwnsGuild(user: Discord.User, guild: Discord.Guild): Promise<boolean> {
+export async function userOwnsGuild(user: User, guild: Guild): Promise<boolean> {
 	return await userHasRoleCategoryInGuild(user, ROLE_CATEGORY_OWNER, guild);
 }

--- a/src/useGuildStorage.ts
+++ b/src/useGuildStorage.ts
@@ -1,6 +1,5 @@
-import type Discord from "discord.js";
+import type { Guild, Snowflake, TextChannel } from "discord.js";
 import type { Role } from "@prisma/client";
-import type { Snowflake } from "discord.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX } from "./constants/database.js";
 import { getEnv } from "./helpers/environment.js";
 import { useRepository } from "./database/useDatabase.js";
@@ -9,7 +8,7 @@ import { useRepository } from "./database/useDatabase.js";
  * Retrives the list of Discord Role IDs whose members have permission to manage
  * the guild's queue limits, content, and open status.
  */
-export async function getQueueAdminRoles(guild: Discord.Guild): Promise<Array<Snowflake>> {
+export async function getQueueAdminRoles(guild: Guild): Promise<Array<Snowflake>> {
 	const storedAdminRoles = (
 		await useRepository("role", roles =>
 			roles.findMany({
@@ -32,7 +31,7 @@ export async function getQueueAdminRoles(guild: Discord.Guild): Promise<Array<Sn
  * Retrieves the list of Discord Role IDs whose members have
  * permission to manage the guild.
  */
-export async function getGuildAdminRoles(guild: Discord.Guild): Promise<Array<Snowflake>> {
+export async function getGuildAdminRoles(guild: Guild): Promise<Array<Snowflake>> {
 	return (
 		await useRepository("role", roles =>
 			roles.findMany({
@@ -54,7 +53,7 @@ export async function getGuildAdminRoles(guild: Discord.Guild): Promise<Array<Sn
 export async function updateRole(
 	roleId: Snowflake,
 	attrs: Partial<Pick<Role, "definesGuildAdmin" | "definesQueueAdmin">>,
-	guild: Discord.Guild
+	guild: Guild
 ): Promise<void> {
 	if (!roleId) return;
 	if (Object.keys(attrs).length === 0) return; // nothing to update
@@ -90,7 +89,7 @@ export async function removeRole(roleId: Snowflake): Promise<void> {
 }
 
 /** Retrieves the guild's queue channel ID, if it exists. */
-export async function getQueueChannelId(guild: Discord.Guild): Promise<Snowflake | null> {
+export async function getQueueChannelId(guild: Guild): Promise<Snowflake | null> {
 	const guildInfo = await useRepository("guild", guilds =>
 		guilds.findUnique({
 			where: { id: guild.id },
@@ -102,8 +101,8 @@ export async function getQueueChannelId(guild: Discord.Guild): Promise<Snowflake
 
 /** Sets the guild's queue channel. */
 export async function setQueueChannel(
-	channel: Discord.TextChannel | Snowflake | null,
-	guild: Discord.Guild
+	channel: TextChannel | Snowflake | null,
+	guild: Guild
 ): Promise<void> {
 	let currentQueue: Snowflake | null;
 
@@ -129,7 +128,7 @@ export async function setQueueChannel(
 }
 
 /** Retrieves the guild's message command prefix. */
-export async function getCommandPrefix(guild: Discord.Guild | null | undefined): Promise<string> {
+export async function getCommandPrefix(guild: Guild | null | undefined): Promise<string> {
 	if (!guild || !guild.id) return DEFAULT_MESSAGE_COMMAND_PREFIX;
 	const guildInfo = await useRepository("guild", guilds =>
 		guilds.findUnique({
@@ -141,10 +140,7 @@ export async function getCommandPrefix(guild: Discord.Guild | null | undefined):
 }
 
 /** Sets the guild's message command prefix. */
-export async function setCommandPrefix(
-	guild: Discord.Guild,
-	messageCommandPrefix: string
-): Promise<void> {
+export async function setCommandPrefix(guild: Guild, messageCommandPrefix: string): Promise<void> {
 	if (!messageCommandPrefix) throw new TypeError("New prefix cannot be empty");
 
 	await useRepository("guild", guilds =>
@@ -163,7 +159,7 @@ export async function setCommandPrefix(
 }
 
 /** Get's the queue's current open status. */
-export async function isQueueOpen(guild: Discord.Guild): Promise<boolean> {
+export async function isQueueOpen(guild: Guild): Promise<boolean> {
 	const guildInfo = await useRepository("guild", guilds =>
 		guilds.findUnique({
 			where: { id: guild.id },
@@ -174,7 +170,7 @@ export async function isQueueOpen(guild: Discord.Guild): Promise<boolean> {
 }
 
 /** Sets the guild's queue-open status. */
-export async function setQueueOpen(isQueueOpen: boolean, guild: Discord.Guild): Promise<void> {
+export async function setQueueOpen(isQueueOpen: boolean, guild: Guild): Promise<void> {
 	await useRepository("guild", async guilds => {
 		const guildInfo = await guilds.findUnique({ where: { id: guild.id } });
 		if (isQueueOpen && !(guildInfo?.currentQueue ?? "")) {

--- a/tests/discordUtils/commandResponse.ts
+++ b/tests/discordUtils/commandResponse.ts
@@ -1,10 +1,10 @@
-import type Discord from "discord.js";
+import type { Snowflake } from "discord.js";
 import { sendCommand } from "./sendMessage";
 import { requireEnv, useTesterClient } from "./testerClient";
 import { waitForMessage } from "./messageDispatch";
 
-const UUT_ID: Discord.Snowflake = requireEnv("BOT_TEST_ID");
-const TEST_CHANNEL_ID: Discord.Snowflake = requireEnv("CHANNEL_ID");
+const UUT_ID: Snowflake = requireEnv("BOT_TEST_ID");
+const TEST_CHANNEL_ID: Snowflake = requireEnv("CHANNEL_ID");
 
 /**
  * Sends a command message in the test channel, and waits for
@@ -22,7 +22,7 @@ export async function commandResponseInTestChannel(
 	command: string,
 	expectToContain: string | undefined = undefined
 ): Promise<string | null> {
-	const channelId: Discord.Snowflake = TEST_CHANNEL_ID;
+	const channelId: Snowflake = TEST_CHANNEL_ID;
 	return await useTesterClient(async client => {
 		const commandMsg = await sendCommand(client, command, channelId);
 		const message = await waitForMessage(response => {

--- a/tests/testUtils/logger.ts
+++ b/tests/testUtils/logger.ts
@@ -1,4 +1,4 @@
-import winston from "winston";
+import * as winston from "winston";
 
 export type Logger = winston.Logger;
 export type LogLevel = "silly" | "debug" | "verbose" | "info" | "warn" | "error";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
 		"module": "CommonJS",
 		"lib": ["ES2021"],
 		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
 		"declaration": false,

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,5 +1,5 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": ["src/**/*.ts", "src/**/*.json"],
+	"include": ["src/**/*.ts", "src/**/*.json", "rollup.config.ts"],
 	"exclude": ["src/**/*.test.ts", "**/__mocks__/**/*.ts", "scripts/**/*"]
 }


### PR DESCRIPTION
These changes let us minify our compiled output from a whole folder of JS source to a single file of JS source, plus whatever's in the node_modules folder.
- dist/server.js is \*almost\* self-contained. Only four top-level dependencies (`discord.js`, `undici`, `winston`, and `yargs`) remain marked as "external," living for now in node_modules. Node built-ins, of course, are also required.
- These four dependencies have lots of circular dependencies, and I'm not yet comfortable letting those through to the bundle without lots more testing than I'm prepared to do right now.
- Some of these dependencies make use of [`eval`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval), which is spoopy. Prisma's use of `eval` seems tame, operating only on string literals. `discord.js` uses `eval` with arbitrary strings. I'm not comfy letting that one into the bundle until that is fixed.