### PR TITLE
feat(url): Allow hiding embeds using angle brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for invoking localized command names with message commands. For example, `?usuarioinfo` now behaves the same as `?userinfo`. Any user can execute a command in any supported language.
 
 ### Changed
+- `/sr` and `/video` now support hiding embeds using Discord's standard angle-brackets method. Simply wrap your link in `<` and `>`, and Gamgee will parse the link in the usual way, taking care to avoid embedding the title and thumbnail publicly.
 - BREAKING: Changed the way database migrations happen. After you update, please run `npm run baseline` if you do not wish your database to be reset. This command adds a field to your database that lets our ORM know that its schema is up to date. You should only have to do this once.
 - BREAKING: Replaced the `DATABASE_FOLDER` environment variable with a new required `DATABASE_URL` variable. Please add this variable to your `.env` file, and set it to the value `"file:{absolute path to your database file}"`. See the [README](/README.md#selecting-a-database-file-location) for an example.
 - Renamed the `entry-duration` queue limit ID to `entry-duration-max`. This makes more sense alongside the `entry-duration-min` limit ID.

--- a/src/actions/queue/processSongRequest.ts
+++ b/src/actions/queue/processSongRequest.ts
@@ -22,10 +22,22 @@ import {
 } from "../../useQueueStorage.js";
 
 export interface SongRequest {
+	/** The URL where the track may be found. */
 	songUrl: URL;
+
+	/** The command context of the request. */
 	context: CommandContext;
+
+	/** The queue channel where the request should land if accepted. */
 	queueChannel: Discord.TextChannel;
+
+	/**
+	 * The message that contains the original embed, if we sent
+	 * one. If the user sent one, this value should be `null`.
+	 */
 	publicPreemptiveResponse: Discord.Message | null;
+
+	/** The place where log messages should be sent. */
 	logger: Logger;
 }
 

--- a/src/commands/songRequest.test.ts
+++ b/src/commands/songRequest.test.ts
@@ -42,6 +42,7 @@ mockGetVideoDetails.mockImplementation(async (url: string) => {
 
 import type Discord from "discord.js";
 import type { GuildedCommandContext } from "./Command.js";
+import type { ReadonlyTuple } from "type-fest";
 import { ApplicationCommandOptionType } from "discord.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX } from "../constants/database.js";
 import { sr as songRequest } from "./songRequest.js";
@@ -51,7 +52,7 @@ import { useTestLogger } from "../../tests/testUtils/logger.js";
 const logger = useTestLogger();
 
 describe("Song request via URL", () => {
-	const urls: [URL, URL, URL, URL, URL, URL, URL, URL, URL, URL] = [
+	const urls: ReadonlyTuple<URL, 10> = [
 		new URL("https://youtu.be/dQw4w9WgXcQ"),
 		new URL("https://youtu.be/9RAQsdTQIcs"),
 		new URL("https://youtu.be/tao1Ic8qVkM"),

--- a/src/commands/video.ts
+++ b/src/commands/video.ts
@@ -6,6 +6,7 @@ import { getVideoDetails } from "../actions/getVideoDetails.js";
 import { localizations } from "../i18n.js";
 import { resolveStringFromOption } from "../helpers/optionResolvers.js";
 import { richErrorMessage } from "../helpers/richErrorMessage.js";
+import { stopEscapingUriInString } from "../actions/messages/editMessage.js";
 
 // TODO: i18n
 export const video: Command = {
@@ -33,7 +34,12 @@ export const video: Command = {
 				ephemeral: true
 			});
 		}
-		const urlString: string = resolveStringFromOption(firstOption);
+		const escapedSongUrlString = resolveStringFromOption(firstOption).trim();
+		const shouldHideEmbeds =
+			escapedSongUrlString.startsWith("<") && escapedSongUrlString.endsWith(">");
+		const urlString = shouldHideEmbeds
+			? stopEscapingUriInString(escapedSongUrlString)
+			: escapedSongUrlString;
 
 		const supportedPlatformsList =
 			"https://github.com/AverageHelper/Gamgee#supported-music-platforms";
@@ -55,7 +61,12 @@ export const video: Command = {
 
 			if (type === "interaction") {
 				// We haven't had this link embedded yet
-				push(video.url, response);
+				if (shouldHideEmbeds) {
+					// If the user doesn't want it embedded, don't embed
+					push(`<${video.url}>`, response);
+				} else {
+					push(video.url, response);
+				}
 				pushNewLine(response);
 			}
 

--- a/tests/commandsAsAdmin.test.ts
+++ b/tests/commandsAsAdmin.test.ts
@@ -72,6 +72,11 @@ describe("Command as admin", function () {
 				const content = await commandResponseInTestChannel(`sr ${url}`, NO_QUEUE);
 				expectToContain(content?.toLowerCase(), NO_QUEUE);
 			});
+
+			it("url request with embed hidden does nothing", async function () {
+				const content = await commandResponseInTestChannel(`sr <${url}>`, NO_QUEUE);
+				expectToContain(content?.toLowerCase(), NO_QUEUE);
+			});
 		});
 
 		describe("no queue yet", function () {
@@ -152,6 +157,11 @@ describe("Command as admin", function () {
 
 		it("returns the title and duration of a song with suboptimal spacing", async function () {
 			const content = await commandResponseInTestChannel(`video             ${url}`, info);
+			expectValueEqual(content, info);
+		});
+
+		it("returns the title and duration of a song with embed hidden", async function () {
+			const content = await commandResponseInTestChannel(`video <${url}>`, info);
 			expectValueEqual(content, info);
 		});
 	});

--- a/tests/commandsAsPleb.test.ts
+++ b/tests/commandsAsPleb.test.ts
@@ -78,6 +78,16 @@ describe("Command as pleb", function () {
 						expectToContain(content, `Submission Accepted!`);
 					});
 
+					it("accepts a song request with embed hidden", async function () {
+						const content = await commandResponseInTestChannel(
+							`sr <${url}>`,
+							"Submission Accepted!"
+						);
+
+						// TODO: Check that the request appears in the queue as well
+						expectToContain(content, `Submission Accepted!`);
+					});
+
 					it("`sr` alone provides info on how to use the request command", async function () {
 						const content = await commandResponseInTestChannel("sr", "To submit a song, type");
 						expectToContain(content, "To submit a song, type");
@@ -85,6 +95,11 @@ describe("Command as pleb", function () {
 				} else {
 					it("url request tells the user the queue is not open", async function () {
 						const content = await commandResponseInTestChannel(`sr ${url}`, "queue is not open");
+						expectToContain(content, "queue is not open");
+					});
+
+					it("url request tells the user the queue is not open even with embed hidden", async function () {
+						const content = await commandResponseInTestChannel(`sr <${url}>`, "queue is not open");
 						expectToContain(content, "queue is not open");
 					});
 				}
@@ -108,6 +123,11 @@ describe("Command as pleb", function () {
 
 		it("returns the title and duration of a song with suboptimal spacing", async function () {
 			const content = await commandResponseInTestChannel(`video             ${url}`, info);
+			expectToContain(content, info);
+		});
+
+		it("returns the title and duration of a song with embed hidden", async function () {
+			const content = await commandResponseInTestChannel(`video <${url}>`, info);
 			expectToContain(content, info);
 		});
 	});


### PR DESCRIPTION
Allow the use of angle brackets to denote that the link should not create an embed.

`/sr <https://example.com>` and `/video <https://example.com>` behave the same as `/sr https://example.com` and `/video https://example.com`, including message-command variants, except that the angle brackets denote that embeds should be hidden from public view. This is in keeping with Discord's normal embed-hiding convention.

The queue will retain its embeds, since Gamgee processes URLs internally anyway; embeds will only be hidden from public view, as users would expect by posting links this way.