### PR TITLE
fix(sr): Hide bad embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.2] - 2022-09-24
+### Changed
+- Internal rejection logs now have more context.
+
 ### Fixed
 - Submissions made with `/sr` are now hidden properly when the submission is rejected, matching the behavior of `?sr`.
 
@@ -381,7 +384,7 @@ After updating, be sure to run `npm ci && npm run build:clean && npm run migrate
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/AverageHelper/Gamgee/compare/v2.0.1...HEAD
+[2.0.2]: https://github.com/AverageHelper/Gamgee/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/AverageHelper/Gamgee/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/AverageHelper/Gamgee/compare/v1.8.3...v2.0.0
 [1.8.3]: https://github.com/AverageHelper/Gamgee/compare/v1.8.2...v1.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Submissions made with `/sr` are now hidden properly when the submission is rejected, matching the behavior of `?sr`.
+
 ## [2.0.0] - 2022-09-21
 ### Added
 - Support for invoking localized command names with message commands. For example, `?usuarioinfo` now behaves the same as `?userinfo`. Any user can execute a command in any supported language.
@@ -373,6 +377,7 @@ After updating, be sure to run `npm ci && npm run build:clean && npm run migrate
 ### Added
 - Initial commit
 
+[Unreleased]: https://github.com/AverageHelper/Gamgee/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/AverageHelper/Gamgee/compare/v1.8.3...v2.0.0
 [1.8.3]: https://github.com/AverageHelper/Gamgee/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/AverageHelper/Gamgee/compare/v1.8.1...v1.8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gamgee",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gamgee",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "LICENSE",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gamgee",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "A Discord bot for managing a song request queue.",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
- Rejection behavior should match between `?sr` and `/sr`.
- Added more context to rejection logs.