### PR TITLE
fix: PM2 startup loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2023-02-24
+### Fixed
+- Startup loop under PM2 when the `NODE_ENV` environment variable is't available.
+
 ## [2.0.5] - 2023-02-14
 ### Added
 - We now verify on startup that all commands were deployed.
@@ -406,6 +410,7 @@ After updating, be sure to run `npm ci && npm run build:clean && npm run migrate
 ### Added
 - Initial commit
 
+[2.0.6]: https://github.com/AverageHelper/Gamgee/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/AverageHelper/Gamgee/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/AverageHelper/Gamgee/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/AverageHelper/Gamgee/compare/v2.0.2...v2.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gamgee",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gamgee",
-			"version": "2.0.5",
+			"version": "2.0.6",
 			"license": "LICENSE",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gamgee",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "A Discord bot for managing a song request queue.",
 	"private": true,
 	"scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import "source-map-support/register.js";
 import { Client, GatewayIntentBits, Partials } from "discord.js";
-import { requireEnv } from "./helpers/environment.js";
+import { getEnv, requireEnv } from "./helpers/environment.js";
 import { richErrorMessage } from "./helpers/richErrorMessage.js";
 import { registerEventHandlers } from "./events/index.js";
 import { useLogger } from "./logger.js";
@@ -46,7 +46,7 @@ export async function _main(logger = useLogger()): Promise<void> {
 
 /* istanbul ignore next */
 // Not Constantinople
-if (requireEnv("NODE_ENV") !== "test") {
+if (getEnv("NODE_ENV") !== "test") {
 	// Jest will never hit this without hax, but Mocha should:
 	void _main();
 }


### PR DESCRIPTION
Apparently, PM2 doesn't normally inject the `NODE_ENV` variable unless you specify an environment explicitly with `--env production` or the like. I really _should_ be doing that anyway, but Gamgee _should_ not boot-loop when `NODE_ENV` is missing. Let's fix that!