### PR TITLE
fix: Skip fancy coverage reports for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,7 @@ jobs:
           node-version: 16.10.x
       - run: npm ci
       - run: npm run build
-      - name: Run npm run test:src
-        uses: ArtiomTr/jest-coverage-report-action@v2.1.1
-        with:
-          skip-step: install # we already ran `npm ci`
-          test-script: npm run test:src
-        env:
-          CI: true
-          NODE_ENV: "test"
+      - run: npm run test:src
 
   test_18:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately, coverage reports fail for external PRs. [There is a fix](https://github.com/ArtiomTr/jest-coverage-report-action/issues/327#issuecomment-1416769753), but it involves reorganizing my CI/CD pipeline.

We'll just skip it for now.