### PR TITLE
Don't hard-code GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,1 @@
-# These are supported funding model platforms
-
-github: AverageHelper # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: "https://average.name/support"

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ You could add that bot to your own server if you'd like (coming soon™), or you
 If you'd like to run natively, the following command should verify you have the prerequisites:
 
 ```sh
-$ npm -v && node -v
-7.20.3
-v16.15.1
+npm -v && node -v
 ```
 
 For running the container, you don't need anything other than a Docker-compatible container runtime.
@@ -117,9 +115,9 @@ The rest of the steps should be handled automatically.
 ### Clone the Repo
 
 ```sh
-$ cd path/to/parent
-$ git clone https://github.com/AverageHelper/Gamgee.git
-$ cd Gamgee
+cd path/to/parent
+git clone https://github.com/AverageHelper/Gamgee.git
+cd Gamgee
 ```
 
 Create a file called `.env` in the root of this project folder. Paste your token into that file:
@@ -141,7 +139,7 @@ LOG_LEVEL={silly | debug | verbose | info | warn | error}
 ### Install dependencies
 
 ```sh
-$ npm install
+npm install
 ```
 
 ### Initialise the Bot
@@ -149,7 +147,7 @@ $ npm install
 The first time you download the source, you'll need to run this command before you run the bot:
 
 ```sh
-$ npm run firstrun
+npm run firstrun
 ```
 
 This will ensure a clean build environment, build the source code, initialise the database, then deploy the commands.
@@ -157,7 +155,7 @@ This will ensure a clean build environment, build the source code, initialise th
 #### Build Sources for Debugging
 
 ```sh
-$ npm run setup
+npm run setup
 ```
 
 #### Manually Register Slash Commands
@@ -165,7 +163,7 @@ $ npm run setup
 In case you'd like to manually deploy Gamgee's [Slash Commands](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ), you can use the following command:
 
 ```sh
-$ npm run commands:deploy
+npm run commands:deploy
 ```
 
 Keep in mind that this requires a valid Discord bot token!
@@ -175,11 +173,19 @@ Keep in mind that this requires a valid Discord bot token!
 Since Gamgee is just a Node script, any Node process manager will do.
 
 ```sh
-$ node .
-# or
-$ npm start
-# or
-$ pm2 start .
+node .
+```
+
+or
+
+```sh
+npm start
+```
+
+or
+
+```sh
+pm2 start .
 ```
 
 ## Advanced configuration

--- a/src/actions/getVideoDetails.test.ts
+++ b/src/actions/getVideoDetails.test.ts
@@ -1,5 +1,4 @@
 import type { VideoDetails } from "./getVideoDetails.js";
-import { URL } from "node:url";
 import { VideoError } from "../errors/VideoError.js";
 
 jest.mock("./network/getBandcampTrack.js", () => ({ getBandcampTrack: jest.fn() }));

--- a/src/actions/getVideoDetails.ts
+++ b/src/actions/getVideoDetails.ts
@@ -4,7 +4,6 @@ import { getPonyFmTrack } from "./network/getPonyFmTrack.js";
 import { getSoundCloudTrack } from "./network/getSoundCloudTrack.js";
 import { getYouTubeVideo } from "./network/getYouTubeVideo.js";
 import { richErrorMessage } from "../helpers/richErrorMessage.js";
-import { URL } from "node:url";
 import { useLogger } from "../logger.js";
 
 export interface VideoDetails {

--- a/src/actions/network/getBandcampTrack.test.ts
+++ b/src/actions/network/getBandcampTrack.test.ts
@@ -1,6 +1,5 @@
 import type { Result } from "htmlmetaparser";
 import { expectDefined, expectValueEqual } from "../../../tests/testUtils/expectations/jest.js";
-import { URL } from "node:url";
 import { VideoError } from "../../errors/VideoError.js";
 
 // Mock fetchMetadata

--- a/src/actions/network/getBandcampTrack.ts
+++ b/src/actions/network/getBandcampTrack.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import type { VideoDetails } from "../getVideoDetails.js";
 import { fetchMetadata } from "../../helpers/fetchMetadata.js";
 import { isString } from "../../helpers/guards.js";

--- a/src/actions/network/getPonyFmTrack.test.ts
+++ b/src/actions/network/getPonyFmTrack.test.ts
@@ -1,6 +1,5 @@
 import { expectDefined, expectValueEqual } from "../../../tests/testUtils/expectations/jest.js";
 import { Response } from "cross-fetch";
-import { URL } from "node:url";
 import { VideoError } from "../../errors/VideoError.js";
 
 // Mock fetch

--- a/src/actions/network/getPonyFmTrack.ts
+++ b/src/actions/network/getPonyFmTrack.ts
@@ -1,78 +1,30 @@
+import type { Infer } from "superstruct";
 import type { VideoDetails } from "../getVideoDetails.js";
 import { fetchWithTimeout } from "../../helpers/fetch.js";
-import { isObject, isString } from "../../helpers/guards.js";
 import { InvalidPonyFmUrlError, VideoError } from "../../errors/index.js";
+import { is, string, type } from "superstruct";
 
-// Based on https://github.com/Poniverse/Pony.fm/blob/a1522f3cd73d849099e4a3d897656dc8c4795dd7/app/Http/Controllers/Api/V1/TracksController.php#L129
-interface PonyFmTrackAPIResponse {
-	// id: number;
-	title: string;
-	// description: string;
-	// lyrics: string;
-	// user: {
-	//	id: number;
-	//	name: string;
-	//	url: string;
-	//	avatars: {
-	//		thumbnail: string;
-	//		small: string;
-	//		normal: string;
-	//	};
-	// };
-	// stats: {
-	//	views: number;
-	//	plays: number;
-	//	downloads: number;
-	//	comments: number;
-	//	favourites: number;
-	// };
-	url: string;
-	// is_vocal: boolean;
-	// is_explicit: boolean;
-	// is_downloadable: boolean;
-	// published_at: {
-	//	date: string;
-	//	timezone_type: number;
-	//	timezone: string;
-	// };
-	duration: string;
-	// genre?: {
-	//	id: number;
-	//	name: string;
-	// };
-	// type: {
-	//	id: number;
-	//	name: string;
-	// };
-	// covers: {
-	//	thumbnail: string;
-	//	small: string;
-	//	normal: string;
-	// };
-	// source: string;
-	// streams: {
-	//	mp3: {
-	//		url: string;
-	//		mime_type: string;
-	//	};
-	// };
+// From https://github.com/Poniverse/Pony.fm/blob/a1522f3cd73d849099e4a3d897656dc8c4795dd7/app/Http/Controllers/Api/V1/TracksController.php#L129
+const ponyFmTrackAPIResponse = type({
+	title: string(),
+	url: string(),
+	duration: string()
+});
+
+type PonyFmTrackAPIResponse = Infer<typeof ponyFmTrackAPIResponse>;
+
+function isPonyFmTrackAPIResponse(tbd: unknown): tbd is PonyFmTrackAPIResponse {
+	return is(tbd, ponyFmTrackAPIResponse);
 }
 
-function isPonyFmTrackAPIResponse(resp: unknown): resp is PonyFmTrackAPIResponse {
-	return (
-		isObject(resp) &&
-		isString((resp as unknown as PonyFmTrackAPIResponse).title) &&
-		isString((resp as unknown as PonyFmTrackAPIResponse).duration) &&
-		isString((resp as unknown as PonyFmTrackAPIResponse).url)
-	);
-}
+const ponyFmTrackAPIError = type({
+	message: string()
+});
 
-interface PonyFmTrackAPIError {
-	message: string;
-}
+type PonyFmTrackAPIError = Infer<typeof ponyFmTrackAPIError>;
 
-function isPonyFmTrackAPIError(resp: unknown): resp is PonyFmTrackAPIError {
-	return isObject(resp) && isString((resp as unknown as PonyFmTrackAPIError).message);
+function isPonyFmTrackAPIError(tbd: unknown): tbd is PonyFmTrackAPIError {
+	return is(tbd, ponyFmTrackAPIError);
 }
 
 /**

--- a/src/actions/network/getPonyFmTrack.ts
+++ b/src/actions/network/getPonyFmTrack.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import type { VideoDetails } from "../getVideoDetails.js";
 import { fetchWithTimeout } from "../../helpers/fetch.js";
 import { isObject, isString } from "../../helpers/guards.js";

--- a/src/actions/network/getSoundCloudTrack.test.ts
+++ b/src/actions/network/getSoundCloudTrack.test.ts
@@ -1,5 +1,4 @@
 import type { Song, SongInfoOptions } from "soundcloud-scraper";
-import { URL } from "node:url";
 import {
 	expectDefined,
 	expectPositive,

--- a/src/actions/network/getSoundCloudTrack.ts
+++ b/src/actions/network/getSoundCloudTrack.ts
@@ -1,7 +1,6 @@
 import type { VideoDetails } from "../getVideoDetails.js";
 import { fetchWithTimeout } from "../../helpers/fetch.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
-import { URL } from "node:url";
 import { useLogger } from "../../logger.js";
 import { VideoError } from "../../errors/VideoError.js";
 import SoundCloud from "soundcloud-scraper";

--- a/src/actions/network/getYouTubeVideo.test.ts
+++ b/src/actions/network/getYouTubeVideo.test.ts
@@ -1,7 +1,6 @@
 import type { videoInfo, getInfoOptions } from "ytdl-core";
 import { expectDefined, expectValueEqual } from "../../../tests/testUtils/expectations/jest.js";
 import { InvalidYouTubeUrlError, UnavailableError } from "../../errors/index.js";
-import { URL } from "node:url";
 
 // Mock ytdl
 jest.mock("ytdl-core", () => ({

--- a/src/actions/network/getYouTubeVideo.ts
+++ b/src/actions/network/getYouTubeVideo.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import type { VideoDetails } from "../getVideoDetails.js";
 import type { videoInfo as YTVideoInfo } from "ytdl-core";
 import { getBasicInfo, validateURL } from "ytdl-core";

--- a/src/actions/queue/processSongRequest.test.ts
+++ b/src/actions/queue/processSongRequest.test.ts
@@ -52,7 +52,6 @@ const mockChannelSend = jest.fn() as jest.Mock<Promise<unknown>, [string]>;
 import type { CommandContext, MessageCommandContext } from "../../commands/CommandContext.js";
 import type { SongRequest } from "./processSongRequest.js";
 import { processSongRequest } from "./processSongRequest.js";
-import { URL } from "node:url";
 import { useTestLogger } from "../../../tests/testUtils/logger.js";
 
 describe("Song request pipeline", () => {

--- a/src/actions/queue/processSongRequest.ts
+++ b/src/actions/queue/processSongRequest.ts
@@ -2,7 +2,6 @@ import type { CommandContext } from "../../commands/index.js";
 import type { Logger } from "../../logger.js";
 import type { Message, TextChannel } from "discord.js";
 import type { UnsentQueueEntry } from "../../useQueueStorage.js";
-import type { URL } from "node:url";
 import { composed, createPartialString, push, pushNewLine } from "../../helpers/composeStrings.js";
 import { deleteMessage } from "../../actions/messages/index.js";
 import { durationString } from "../../helpers/durationString.js";

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -1,5 +1,4 @@
 import type { ComponentEmojiResolvable } from "discord.js";
-import type { URL } from "node:url";
 import {
 	ActionRowBuilder,
 	ButtonBuilder,

--- a/src/commands/howto.ts
+++ b/src/commands/howto.ts
@@ -2,6 +2,7 @@ import type { GuildedCommand } from "./Command.js";
 import { getCommandPrefix } from "../useGuildStorage.js";
 import { localizations } from "../i18n.js";
 import { SLASH_COMMAND_INTENT_PREFIX } from "../constants/database.js";
+import { supportedPlatformsList } from "../constants/repository.js";
 import {
 	composed,
 	createPartialString,
@@ -42,8 +43,6 @@ export const howto: GuildedCommand = {
 		push("I will respond with a text verification indicating your song has joined the queue!", msg);
 		pushNewLine(msg);
 
-		const supportedPlatformsList =
-			"https://github.com/AverageHelper/Gamgee#supported-music-platforms";
 		const supportedPlatforms =
 			type === "interaction"
 				? `See [our list of supported platforms](<${supportedPlatformsList}>)`

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -1,9 +1,9 @@
 import "../../tests/testUtils/leakedHandles.js";
 
-jest.mock("../helpers/githubMetadata.js");
-import { gitHubMetadata } from "../helpers/githubMetadata.js";
-const mockGitHubMetadata = gitHubMetadata as jest.Mock;
-mockGitHubMetadata.mockResolvedValue({
+jest.mock("../helpers/gitForgeMetadata.js");
+import { gitForgeMetadata } from "../helpers/gitForgeMetadata.js";
+const mockGitForgeMetadata = gitForgeMetadata as jest.Mock;
+mockGitForgeMetadata.mockResolvedValue({
 	languages: {
 		English: 80,
 		Spanish: 10,
@@ -22,7 +22,7 @@ import { useTestLogger } from "../../tests/testUtils/logger.js";
 
 const logger = useTestLogger();
 
-describe("Language Statistics from GitHub", () => {
+describe("Language Statistics from our git forge", () => {
 	let context: CommandContext;
 
 	beforeEach(() => {
@@ -34,13 +34,13 @@ describe("Language Statistics from GitHub", () => {
 		} as unknown as CommandContext;
 	});
 
-	test("asks GitHub about my language statistics", async () => {
+	test("asks our git forge about our language statistics", async () => {
 		const owner = "AverageHelper";
 		const repo = "Gamgee";
 
 		await expect(languages.execute(context)).resolves.toBeUndefined();
-		expect(mockGitHubMetadata).toHaveBeenCalledOnce();
-		expect(mockGitHubMetadata).toHaveBeenCalledWith({ owner, repo });
+		expect(mockGitForgeMetadata).toHaveBeenCalledOnce();
+		expect(mockGitForgeMetadata).toHaveBeenCalledWith({ owner, repo });
 
 		expect(mockReply).toHaveBeenCalled();
 		expect(mockReply).toHaveBeenCalledWith(expect.stringContaining("languages"));

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -1,6 +1,6 @@
-import type { GitHubMetadata } from "../helpers/githubMetadata.js";
+import type { GitForgeMetadata } from "../helpers/gitForgeMetadata.js";
 import type { GlobalCommand } from "./Command.js";
-import { gitHubMetadata } from "../helpers/githubMetadata.js";
+import { gitForgeMetadata } from "../helpers/gitForgeMetadata.js";
 import { locales, localizations } from "../i18n.js";
 import { richErrorMessage } from "../helpers/richErrorMessage.js";
 import { timeoutSeconds } from "../helpers/timeoutSeconds.js";
@@ -8,7 +8,7 @@ import { timeoutSeconds } from "../helpers/timeoutSeconds.js";
 const owner = "AverageHelper";
 const repo = "Gamgee";
 
-let cachedMetadata: GitHubMetadata | null = null;
+let cachedMetadata: GitForgeMetadata | null = null;
 
 // TODO: i18n
 export const languages: GlobalCommand = {
@@ -22,10 +22,10 @@ export const languages: GlobalCommand = {
 			await prepareForLongRunningTasks();
 			if (cachedMetadata === null) {
 				// eslint-disable-next-line require-atomic-updates
-				cachedMetadata = await gitHubMetadata({ owner, repo });
+				cachedMetadata = await gitForgeMetadata({ owner, repo });
 			}
 		} catch (error) {
-			logger.error(richErrorMessage("Failed to get metadata from my GitHub repo.", error));
+			logger.error(richErrorMessage("Failed to get metadata from my git forge.", error));
 			await reply("Erm... I'm not sure :sweat_smile:");
 			await timeoutSeconds(1);
 			await followUp({

--- a/src/commands/songRequest.test.ts
+++ b/src/commands/songRequest.test.ts
@@ -48,7 +48,6 @@ import type { ReadonlyTuple } from "type-fest";
 import { ApplicationCommandOptionType } from "discord.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX } from "../constants/database.js";
 import { sr as songRequest } from "./songRequest.js";
-import { URL } from "node:url";
 import { useTestLogger } from "../../tests/testUtils/logger.js";
 
 const logger = useTestLogger();

--- a/src/commands/songRequest.ts
+++ b/src/commands/songRequest.ts
@@ -8,7 +8,6 @@ import { localizations, t } from "../i18n.js";
 import { logUser } from "../helpers/logUser.js";
 import { processSongRequest } from "../actions/queue/processSongRequest.js";
 import { resolveStringFromOption } from "../helpers/optionResolvers.js";
-import { URL } from "node:url";
 import { useJobQueue } from "@averagehelper/job-queue";
 import {
 	deleteMessage,

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5,6 +5,7 @@ import { getPonyFmTrack } from "../actions/network/getPonyFmTrack.js";
 import { getSoundCloudTrack } from "../actions/network/getSoundCloudTrack.js";
 import { getYouTubeVideo } from "../actions/network/getYouTubeVideo.js";
 import { localizations, t, ti } from "../i18n.js";
+import { supportedPlatformsList } from "../constants/repository.js";
 import { version } from "../version.js";
 
 type FetchTestFunction = typeof getYouTubeVideo;
@@ -106,9 +107,6 @@ export const test: Command = {
 			const embed = new EmbedBuilder();
 			embed.setFooter({ text: `Gamgee v${version}` });
 
-			// TODO: We use this URL in several places. Move it into a central place for us to import and use around
-			const supportedPlatformsList =
-				"https://github.com/AverageHelper/Gamgee#supported-music-platforms";
 			const list = `[${t(
 				"commands.test.responses.supported-platforms",
 				userLocale

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -5,7 +5,6 @@ import { getPonyFmTrack } from "../actions/network/getPonyFmTrack.js";
 import { getSoundCloudTrack } from "../actions/network/getSoundCloudTrack.js";
 import { getYouTubeVideo } from "../actions/network/getYouTubeVideo.js";
 import { localizations, t, ti } from "../i18n.js";
-import { URL } from "node:url";
 import { version } from "../version.js";
 
 type FetchTestFunction = typeof getYouTubeVideo;

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -113,7 +113,7 @@ export const test: Command = {
 			)}](${supportedPlatformsList})`;
 
 			embed.setTitle(t("commands.test.responses.results-header", userLocale));
-			embed.setDescription(ti("commands.test.responses.see-on-github", { list }, userLocale));
+			embed.setDescription(ti("commands.test.responses.see-on-forge", { list }, userLocale));
 			results.forEach(result => addResult(result, embed));
 
 			const anyFailures = results.some(result => result.error !== undefined);

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,4 +1,5 @@
 import type { Command } from "./Command.js";
+import { changelog } from "../constants/repository.js";
 import { localizations, ti } from "../i18n.js";
 import { version as gamgeeVersion } from "../version.js";
 import { randomCelebration, unwrappingFirstWith } from "../helpers/randomStrings.js";
@@ -22,8 +23,6 @@ export const version: Command = {
 		const systemName = "Gamgee Core";
 
 		if (type === "interaction") {
-			const repo = "https://github.com/AverageHelper/Gamgee";
-			const changelog = `${repo}/blob/main/CHANGELOG.md`; // TODO: Select the current version's heading
 			// Discord lets bots link stuff in Markdown syntax, but it'll also embed by default.
 			// We use angled brackets (`<` and `>`) to prevent the embed.
 			return await reply(

--- a/src/commands/video.ts
+++ b/src/commands/video.ts
@@ -7,6 +7,7 @@ import { localizations, t, ti } from "../i18n.js";
 import { resolveStringFromOption } from "../helpers/optionResolvers.js";
 import { richErrorMessage } from "../helpers/richErrorMessage.js";
 import { stopEscapingUriInString } from "../actions/messages/editMessage.js";
+import { supportedPlatformsList } from "../constants/repository.js";
 
 export const video: Command = {
 	name: "video",
@@ -47,8 +48,6 @@ export const video: Command = {
 			? stopEscapingUriInString(escapedSongUrlString)
 			: escapedSongUrlString;
 
-		const supportedPlatformsList =
-			"https://github.com/AverageHelper/Gamgee#supported-music-platforms";
 		const supportedPlatform =
 			type === "interaction"
 				? `[${t(

--- a/src/constants/repository.ts
+++ b/src/constants/repository.ts
@@ -1,0 +1,10 @@
+import { version } from "../version.js";
+
+/** Where our codebase lives. */
+export const repository = new URL("https://github.com/AverageHelper/Gamgee");
+
+/** A link to our changelog file. */
+export const changelog = `${repository.href}/blob/v${version}/CHANGELOG.md`;
+
+/** A link to the definitive list of our supported music platforms. */
+export const supportedPlatformsList = `${repository.href}#supported-music-platforms`;

--- a/src/database/sqliteDataSource.ts
+++ b/src/database/sqliteDataSource.ts
@@ -1,7 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { requireEnv } from "../helpers/environment.js";
 import { richErrorMessage } from "../helpers/richErrorMessage.js";
-import { URL } from "node:url";
 import { useLogger } from "../logger.js";
 
 const logger = useLogger();

--- a/src/errors/InvalidPonyFmUrlError.ts
+++ b/src/errors/InvalidPonyFmUrlError.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import { VideoError } from "./VideoError.js";
 
 export class InvalidPonyFmUrlError extends VideoError {

--- a/src/errors/InvalidYouTubeUrlError.ts
+++ b/src/errors/InvalidYouTubeUrlError.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import { VideoError } from "./VideoError.js";
 
 export class InvalidYouTubeUrlError extends VideoError {

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import { VideoError } from "./VideoError.js";
 
 export class NotFoundError extends VideoError {

--- a/src/errors/UnavailableError.ts
+++ b/src/errors/UnavailableError.ts
@@ -1,4 +1,3 @@
-import type { URL } from "node:url";
 import { VideoError } from "./VideoError.js";
 
 export class UnavailableError extends VideoError {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -3,6 +3,7 @@ import { deployCommands } from "../actions/deployCommands.js";
 import { getEnv } from "../helpers/environment.js";
 import { onEvent } from "../helpers/onEvent.js";
 import { parseArgs } from "../helpers/parseArgs.js";
+import { repository } from "../constants/repository.js";
 import { revokeCommands } from "../actions/revokeCommands.js";
 import { verifyCommandDeployments } from "../actions/verifyCommandDeployments.js";
 import { version as gamgeeVersion } from "../version.js";
@@ -62,7 +63,7 @@ function setActivity(client: Client<true>): ClientPresence {
 	// multiline string on the bot's user profile.
 	return client.user.setActivity({
 		type: ActivityType.Playing,
-		name: "Source: github.com/AverageHelper/Gamgee",
-		url: "https://github.com/AverageHelper/Gamgee"
+		name: `Source: ${repository.hostname}${repository.pathname}`,
+		url: repository.href
 	});
 }

--- a/src/handleCommand.test.ts
+++ b/src/handleCommand.test.ts
@@ -4,11 +4,11 @@ import { ApplicationCommandOptionType, userMention } from "discord.js";
 import { expectArrayOfLength, expectDefined } from "../tests/testUtils/expectations/jest.js";
 import { DEFAULT_MESSAGE_COMMAND_PREFIX as PREFIX } from "./constants/database.js";
 
-jest.mock("./helpers/githubMetadata.js");
+jest.mock("./helpers/gitForgeMetadata.js");
 
-import { gitHubMetadata } from "./helpers/githubMetadata.js";
-const mockGitHubMetadata = gitHubMetadata as jest.Mock;
-mockGitHubMetadata.mockResolvedValue({
+import { gitForgeMetadata } from "./helpers/gitForgeMetadata.js";
+const mockGitForgeMetadata = gitForgeMetadata as jest.Mock;
+mockGitForgeMetadata.mockResolvedValue({
 	name: "Gamgee",
 	full_name: "Gamgee",
 	private: false,

--- a/src/helpers/fetchMetadata.ts
+++ b/src/helpers/fetchMetadata.ts
@@ -1,5 +1,4 @@
 import type { Result } from "htmlmetaparser";
-import type { URL } from "node:url";
 import { fetchWithTimeout } from "./fetch.js";
 import { Handler } from "htmlmetaparser";
 import { Parser } from "htmlparser2";

--- a/src/helpers/githubMetadata.ts
+++ b/src/helpers/githubMetadata.ts
@@ -1,6 +1,5 @@
 import { fetch } from "./fetch.js";
 import { isBoolean, isNumber, isObject, isString, isUrlString } from "./guards.js";
-import { URL } from "node:url";
 import { useLogger } from "../logger.js";
 
 type RequestInit = Exclude<Parameters<typeof fetch>[1], undefined>;

--- a/src/helpers/guards.ts
+++ b/src/helpers/guards.ts
@@ -1,13 +1,11 @@
+export { default as isFunction } from "lodash/isFunction.js";
+
 export function isNonEmptyArray<T>(array: ReadonlyArray<T>): array is NonEmptyArray<T> {
 	return array.length > 0;
 }
 
-export function isNotNull<T>(tbd: T): tbd is Exclude<T, null> {
+export function isNotNull<T>(tbd: T | null): tbd is T {
 	return tbd !== null;
-}
-
-export function isObject(tbd: unknown): tbd is Record<string, unknown> {
-	return typeof tbd === "object" && tbd !== null && !Array.isArray(tbd);
 }
 
 export function isString(tbd: unknown): tbd is string {

--- a/src/helpers/guards.ts
+++ b/src/helpers/guards.ts
@@ -1,5 +1,3 @@
-import { URL } from "node:url";
-
 export function isNonEmptyArray<T>(array: ReadonlyArray<T>): array is NonEmptyArray<T> {
 	return array.length > 0;
 }

--- a/src/helpers/guards.ts
+++ b/src/helpers/guards.ts
@@ -10,14 +10,6 @@ export function isObject(tbd: unknown): tbd is Record<string, unknown> {
 	return typeof tbd === "object" && tbd !== null && !Array.isArray(tbd);
 }
 
-export function isBoolean(tbd: unknown): tbd is boolean {
-	return tbd !== null && (typeof tbd === "boolean" || tbd instanceof Boolean);
-}
-
-export function isNumber(tbd: unknown): tbd is number {
-	return tbd !== null && (typeof tbd === "number" || tbd instanceof Number);
-}
-
 export function isString(tbd: unknown): tbd is string {
 	return tbd !== null && (typeof tbd === "string" || tbd instanceof String);
 }

--- a/src/helpers/randomStrings.ts
+++ b/src/helpers/randomStrings.ts
@@ -1,4 +1,5 @@
 import type { GuildMember, User } from "discord.js";
+import { isFunction, isString } from "./guards.js";
 import { randomElementOfArray } from "./randomElementOfArray.js";
 import { useLogger } from "../logger.js";
 import {
@@ -9,8 +10,6 @@ import {
 	phrases,
 	questions
 } from "../constants/textResponses.js";
-import isFunction from "lodash/isFunction";
-import { isString } from "./guards.js";
 
 const logger = useLogger();
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -74,7 +74,7 @@ const _: Vocabulary = vocabulary; // ensures our language types are formatted ri
 
 import type { Get, Split } from "type-fest";
 import _get from "lodash/get.js";
-import isString from "lodash/isString.js";
+import { isString } from "./helpers/guards.js";
 
 function split<S extends string, D extends string>(string: S, separator: D): Split<S, D> {
 	return string.split(separator) as Split<S, D>;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Äh, etwas ist schief gelaufen. Schau am besten mal hier rein:",
 				"preamble-success": "Ich habe die Zahlen überprüft und es sieht so aus, als ob es uns allen gut geht!",
 				"results-header": "Testergebnisse nach Plattform",
-				"see-on-github": "Sehen Sie sich die {list} auf unserem GitHub an.",
+				"see-on-forge": "Sehen Sie sich die {list} auf unserem GitHub an.",
 				"supported-platforms": "Liste der unterstützten Plattformen"
 			}
 		},

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Erm, something went wrong. Best look into this:",
 				"preamble-success": "I ran the numbers, and it looks like we're all good!",
 				"results-header": "Test Results by Platform",
-				"see-on-github": "See the {list} on our GitHub.",
+				"see-on-forge": "See the {list} on our GitHub.",
 				"supported-platforms": "list of supported platforms"
 			}
 		},

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Uh, something went wrong. Best look into this:",
 				"preamble-success": "I ran the numbers, and it looks like we're all good!",
 				"results-header": "Test Results by Platform",
-				"see-on-github": "See the {list} on our GitHub.",
+				"see-on-forge": "See the {list} on our GitHub.",
 				"supported-platforms": "list of supported platforms"
 			}
 		},

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Uh, algo salió mal. Mejor mira esto:",
 				"preamble-success": "Corrí los números, ¡y parece que todos estamos bien!",
 				"results-header": "Resultados de la prueba por plataforma",
-				"see-on-github": "Consulte la {list} en nuestro GitHub.",
+				"see-on-forge": "Consulte la {list} en nuestro GitHub.",
 				"supported-platforms": "lista de plataformas compatibles"
 			}
 		},

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Euh, quelque chose s'est mal passé. Le mieux est de regarder ceci:",
 				"preamble-success": "J'ai fait les calculs, et on dirait que tout va bien!",
 				"results-header": "Résultats des tests par plate-forme",
-				"see-on-github": "Consultez la {list} sur notre GitHub.",
+				"see-on-forge": "Consultez la {list} sur notre GitHub.",
 				"supported-platforms": "liste des plates-formes prise en charge"
 			}
 		},

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Valami elromlott. Ez fontos lehet:",
 				"preamble-success": "Osztottam és szoroztam, és úgy tűnik, minden rendben!",
 				"results-header": "Vizsgálat eredményei Platform szerint",
-				"see-on-github": "Tekintse meg a {list} a GitHubon.",
+				"see-on-forge": "Tekintse meg a {list} a GitHubon.",
 				"supported-platforms": "támogatott platformok listáját"
 			}
 		},

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -177,7 +177,7 @@
 				"preamble-failure": "Ué, algo deu errado. Melhor olhar para isso:",
 				"preamble-success": "Eu corri os números, e parece que estamos todos bem!",
 				"results-header": "Resultado dos Testes por Plataforma",
-				"see-on-github": "Consulte a {list} em nosso GitHub.",
+				"see-on-forge": "Consulte a {list} em nosso GitHub.",
 				"supported-platforms": "lista de plataformas compatíveis"
 			}
 		},


### PR DESCRIPTION
I plan to move the repo to [my own git forge](https://git.average.name) soon-ish. It'd be best to not hard-code references to the repo URL and GitHub in the meantime.

- Set my own Support webpage in `Funding.yml`.
- Removed manual imports of `URL` via `node:url`, since [`URL` is a global in all versions of Node that we support](https://nodejs.org/docs/latest-v16.x/api/globals.html#url).
- Improved type safety around external API calls via `superstruct`.
- Consolidated references to our git forge URLs into a `constants` file.
- Replaced references to GitHub proper in code structures with generic verbiage.