### PR TITLE
feat: Mention the cooldown timer's start point in internal logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Internal logging to indicate the start of a user's submission cooldown timer.
 - `.mailmap` file.
 
 ### Changed

--- a/src/actions/queue/processSongRequest.ts
+++ b/src/actions/queue/processSongRequest.ts
@@ -106,8 +106,12 @@ async function acceptSongRequest({
 	logger
 }: SongAcceptance): Promise<void> {
 	logger.debug(`Began enqueuing request at ${Date.now()} from ${logUser(context.user)}`);
-	await pushEntryToQueue(entry, queueChannel);
-	logger.debug(`Enqueued request at ${Date.now()} from ${logUser(context.user)}`);
+	const storedEntry = await pushEntryToQueue(entry, queueChannel);
+	logger.debug(
+		`Enqueued request at ${Date.now()} from ${logUser(
+			context.user
+		)}. Cooldown timer began at ${storedEntry.sentAt.getTime()}`
+	);
 	logger.verbose(`Accepted request from user ${logUser(context.user)}.`);
 	logger.debug(
 		`Pushed new request to queue. Sending public acceptance to user ${logUser(context.user)}`


### PR DESCRIPTION
We now log when a user's cooldown timer begins. Might be useful in debugging event ordering issues.