### PR TITLE
fix: Don't include the user's home directory name in the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"@rollup/plugin-commonjs": "22.0.2",
 				"@rollup/plugin-json": "4.1.0",
 				"@rollup/plugin-node-resolve": "14.1.0",
+				"@rollup/plugin-replace": "5.0.5",
 				"@types/chai": "4.3.3",
 				"@types/humanize-duration": "3.27.1",
 				"@types/jest": "29.5.12",
@@ -1831,6 +1832,67 @@
 			},
 			"peerDependencies": {
 				"rollup": "^2.78.0"
+			}
+		},
+		"node_modules/@rollup/plugin-replace": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+			"integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^5.0.1",
+				"magic-string": "^0.30.3"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+			"integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"dev": true
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+			"version": "0.30.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+			"integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -9673,6 +9735,44 @@
 				"is-builtin-module": "^3.1.0",
 				"is-module": "^1.0.0",
 				"resolve": "^1.19.0"
+			}
+		},
+		"@rollup/plugin-replace": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+			"integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^5.0.1",
+				"magic-string": "^0.30.3"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+					"integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "^1.0.0",
+						"estree-walker": "^2.0.2",
+						"picomatch": "^2.3.1"
+					}
+				},
+				"@types/estree": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+					"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.30.7",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+					"integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/sourcemap-codec": "^1.4.15"
+					}
+				}
 			}
 		},
 		"@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"@rollup/plugin-commonjs": "22.0.2",
 		"@rollup/plugin-json": "4.1.0",
 		"@rollup/plugin-node-resolve": "14.1.0",
+		"@rollup/plugin-replace": "5.0.5",
 		"@types/chai": "4.3.3",
 		"@types/humanize-duration": "3.27.1",
 		"@types/jest": "29.5.12",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,11 +5,25 @@ import analyze from "rollup-plugin-analyzer";
 import commonjs from "@rollup/plugin-commonjs";
 import esbuild from "rollup-plugin-esbuild";
 import json from "@rollup/plugin-json";
+import replace from "@rollup/plugin-replace";
 
 const isProduction = process.env["NODE_ENV"] === "production";
 
+const HOME = process.env["HOME"];
+
 export default defineConfig({
 	plugins: [
+		// Prisma injects the home directory. Remove that:
+		HOME !== undefined
+			? replace({
+					values: {
+						[HOME]: "~"
+					},
+					delimiters: ["", ""],
+					preventAssignment: true
+			  })
+			: null,
+
 		// Transpile source
 		esbuild({
 			tsconfig: "./tsconfig.prod.json",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,4 +1,4 @@
-import { assert, literal, string, type } from "superstruct";
+import { assert, enums, string, type } from "superstruct";
 import { join } from "node:path";
 import { parser as changelogParser } from "keep-a-changelog";
 import { parse as parseSemVer } from "semver";
@@ -59,7 +59,7 @@ const versioned = type({
 });
 const versionedLock = type({
 	version: string(),
-	lockfileVersion: literal(2),
+	lockfileVersion: enums([2, 3]),
 	packages: type({
 		"": type({
 			version: string()


### PR DESCRIPTION
Seems Prisma sometimes hard-codes full file paths in the build output, even tho it's capable of expanding the `~`. This PR adds a build step to shorten paths again so the building user's username name doesn't wind up baked into the build output.