### PR TITLE
feat: youtube api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-08-22
+### Added
+- Use YouTube's first-party API when an API key is provided.
+- The `/test` command now reports when an alternative source is used for querying platforms. This is especially useful to determine whether Gamgee needed to fall back on an Invidius instance when YTDL failed, or when an API key was not configured.
+
 ## [3.0.0] - 2024-08-21
 ### Fixed
 - Version bump because of a breaking change in v2.2.1. (Sorry!!) We now require Node 20. Docker users should be unaffected, since the Dockerfile \*should\* be using the latest Node anyway.
@@ -456,6 +461,7 @@ After updating, be sure to run `npm ci && npm run build:clean && npm run migrate
 ### Added
 - Initial commit
 
+[3.1.0]: https://github.com/AverageHelper/Gamgee/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/AverageHelper/Gamgee/compare/v2.2.1...v3.0.0
 [2.2.1]: https://github.com/AverageHelper/Gamgee/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/AverageHelper/Gamgee/compare/v2.1.1...v2.2.0

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ LOG_LEVEL={silly | debug | verbose | info | warn | error}
 # optional, the level of logs you should see in the console
 # must be one of [silly, debug, verbose, info, warn, error]
 # defaults to `info` in production mode, `error` in test mode, and `debug` in any other mode
+
+SOUNDCLOUD_API_KEY=YOUR_SOUNDCLOUD_KEY_HERE
+# optional, used for communicating with SoundCloud more reliably
+
+YOUTUBE_API_KEY=YOUR_YOUTUBE_KEY_HERE
+# optional, used for communicating with YouTube more reliably
 ```
 
 ### Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gamgee",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gamgee",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"license": "LICENSE",
 			"dependencies": {
 				"@averagehelper/job-queue": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"soundcloud-scraper": "5.0.3",
 				"source-map-support": "0.5.21",
 				"superstruct": "1.0.3",
+				"temporal-polyfill": "0.2.5",
 				"winston": "3.8.1",
 				"winston-daily-rotate-file": "4.7.1",
 				"ytdl-core": "4.11.5"
@@ -6947,6 +6948,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/temporal-polyfill": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
+			"integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+			"dependencies": {
+				"temporal-spec": "^0.2.4"
+			}
+		},
+		"node_modules/temporal-spec": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
+			"integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ=="
+		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13535,6 +13549,19 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true
+		},
+		"temporal-polyfill": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
+			"integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+			"requires": {
+				"temporal-spec": "^0.2.4"
+			}
+		},
+		"temporal-spec": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
+			"integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ=="
 		},
 		"test-exclude": {
 			"version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gamgee",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "A Discord bot for managing a song request queue.",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"soundcloud-scraper": "5.0.3",
 		"source-map-support": "0.5.21",
 		"superstruct": "1.0.3",
+		"temporal-polyfill": "0.2.5",
 		"winston": "3.8.1",
 		"winston-daily-rotate-file": "4.7.1",
 		"ytdl-core": "4.11.5"

--- a/src/actions/getVideoDetails.ts
+++ b/src/actions/getVideoDetails.ts
@@ -7,12 +7,28 @@ import { richErrorMessage } from "../helpers/richErrorMessage.js";
 import { MILLISECONDS_IN_SECOND } from "../constants/time.js";
 import { useLogger } from "../logger.js";
 
+export interface VideoMetaSource {
+	/** The name of the source platform. */
+	platformName: "youtube" | "soundcloud" | "bandcamp" | "pony.fm";
+
+	/** The name of the alternative interface used to source the data. */
+	alternative: string | null;
+}
+
 export interface VideoDetails {
+	/** The canonical URL of the track. */
 	url: string;
+
+	/** The title of the track. */
 	title: string;
+
+	/** The duration of the track. */
 	duration: {
 		seconds: number;
 	};
+
+	/** The source of the track metadata. */
+	metaSource: VideoMetaSource;
 }
 
 /**

--- a/src/actions/network/getBandcampTrack.test.ts
+++ b/src/actions/network/getBandcampTrack.test.ts
@@ -34,21 +34,17 @@ describe("Bandcamp track details", () => {
 		await expect(() => getBandcampTrack(new URL(url))).rejects.toThrow(VideoError);
 	});
 
+	// ISO strings given here are the ones found on Bandcamp as of 22 Aug 2024:
 	test.each`
-		url                                                                             | duration
-		${"https://poniesatdawn.bandcamp.com/track/let-the-magic-fill-your-soul"}       | ${233}
-		${"https://forestrainmedia.com/track/bad-wolf"}                                 | ${277}
-		${"https://lehtmojoe.bandcamp.com/track/were-not-going-home-dallas-stars-2020"} | ${170}
+		url                                                                             | duration | iso
+		${"https://poniesatdawn.bandcamp.com/track/let-the-magic-fill-your-soul"}       | ${233}   | ${"P00H03M53S"}
+		${"https://forestrainmedia.com/track/bad-wolf"}                                 | ${277}   | ${"P00H04M37S"}
+		${"https://lehtmojoe.bandcamp.com/track/were-not-going-home-dallas-stars-2020"} | ${170}   | ${"P00H02M50S"}
 	`(
 		"returns info for Bandcamp track $url, $duration seconds long",
-		async ({ url, duration }: { url: string; duration: number }) => {
+		async ({ url, duration, iso }: { url: string; duration: number; iso: string }) => {
 			mockFetchMetadata.mockResolvedValue({
-				jsonld: [
-					{
-						name: "sample",
-						duration: `0H${Math.floor(duration / 60)}M${duration % 60}S`,
-					},
-				],
+				jsonld: [{ name: "sample", duration: iso }],
 			} as unknown as Result);
 
 			const details = await getBandcampTrack(new URL(url));

--- a/src/actions/network/getBandcampTrack.ts
+++ b/src/actions/network/getBandcampTrack.ts
@@ -1,7 +1,21 @@
 import type { VideoDetails } from "../getVideoDetails.js";
+import { array, is, string, type } from "superstruct";
 import { fetchMetadata } from "../../helpers/fetchMetadata.js";
-import { isString } from "../../helpers/guards.js";
+import { richErrorMessage } from "../../helpers/richErrorMessage.js";
+import { secondsFromIso8601Duration } from "../../helpers/secondsFromIso8601Duration.js";
+import { useLogger } from "../../logger.js";
 import { VideoError } from "../../errors/index.js";
+
+const logger = useLogger();
+
+const bandcampJsonld = array(
+	type({
+		/** The title of the track. */
+		name: string(),
+		/** An ISO 8601 duration string. */
+		duration: string(),
+	}),
+);
 
 /**
  * Gets information about a Bandcamp track.
@@ -17,35 +31,35 @@ import { VideoError } from "../../errors/index.js";
 export async function getBandcampTrack(url: URL, signal?: AbortSignal): Promise<VideoDetails> {
 	const metadata = await fetchMetadata(url, signal);
 
-	type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 	const jsonld = metadata.jsonld ?? [];
-	const json = jsonld[0] as
-		| { name?: string; duration: `${string}H${Digit}${Digit}M${Digit}${Digit}S` }
-		| undefined;
+	if (!is(jsonld, bandcampJsonld)) throw new VideoError("Duration or title not found");
+
+	const json = jsonld[0];
 	if (!json) throw new VideoError("Duration and title not found");
-	if (!json.duration || !isString(json.duration)) throw new VideoError("Duration data not found");
 
-	const durationPropertiesMatch = json.duration.matchAll(/H([0-9]+)M([0-9]+)S/gu);
-	const durationProperties = Array.from(durationPropertiesMatch)[0] as
-		| [string, string, string, ...Array<string>] // at least 3 strings
-		| undefined;
+	const durationString = json["duration"];
+	let durationSeconds: number;
+	try {
+		let durationStringToParse = durationString;
+		// Bandcamp's duration strings often don't parse correctly...
+		if (durationString.startsWith("P00H")) {
+			logger.debug(`Got nonstandard duration string '${durationString}'. Attempting workaround...`);
+			durationStringToParse = `PT${durationString.slice(1)}`;
+		}
+		durationSeconds = secondsFromIso8601Duration(durationStringToParse);
+	} catch (error) {
+		logger.error(
+			richErrorMessage(`Failed to parse ISO 8601 duration string '${durationString}'.`, error),
+		);
+		throw new VideoError("Duration could not be parsed");
+	}
 
-	// Sanity checks (I have a college education and I don't understand regex)
-	if (!durationProperties || durationProperties.length < 3 || !durationProperties.every(isString))
-		throw new VideoError("Duration not found");
-
-	const minutes = Number.parseInt(durationProperties[1], 10);
-	const seconds = Number.parseInt(durationProperties[2], 10);
-	if (Number.isNaN(minutes) || Number.isNaN(seconds)) throw new VideoError("Duration not found");
-
-	const totalSeconds = minutes * 60 + seconds;
-
-	const title: string | null = json.name ?? null;
-	if (title === null || !title) throw new VideoError("Title not found");
+	const title: string = json["name"];
+	if (!title) throw new VideoError("Title not found");
 
 	return {
 		url: url.href,
 		title,
-		duration: { seconds: Math.floor(totalSeconds) },
+		duration: { seconds: durationSeconds },
 	};
 }

--- a/src/actions/network/getBandcampTrack.ts
+++ b/src/actions/network/getBandcampTrack.ts
@@ -1,4 +1,4 @@
-import type { VideoDetails } from "../getVideoDetails.js";
+import type { VideoDetails, VideoMetaSource } from "../getVideoDetails.js";
 import { array, is, string, type } from "superstruct";
 import { fetchMetadata } from "../../helpers/fetchMetadata.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
@@ -16,6 +16,11 @@ const bandcampJsonld = array(
 		duration: string(),
 	}),
 );
+
+const metaSource: Readonly<VideoMetaSource> = {
+	platformName: "bandcamp",
+	alternative: null,
+};
 
 /**
  * Gets information about a Bandcamp track.
@@ -61,5 +66,6 @@ export async function getBandcampTrack(url: URL, signal?: AbortSignal): Promise<
 		url: url.href,
 		title,
 		duration: { seconds: durationSeconds },
+		metaSource,
 	};
 }

--- a/src/actions/network/getPonyFmTrack.ts
+++ b/src/actions/network/getPonyFmTrack.ts
@@ -1,5 +1,5 @@
 import type { Infer } from "superstruct";
-import type { VideoDetails } from "../getVideoDetails.js";
+import type { VideoDetails, VideoMetaSource } from "../getVideoDetails.js";
 import { InvalidPonyFmUrlError, VideoError } from "../../errors/index.js";
 import { is, string, type } from "superstruct";
 
@@ -25,6 +25,11 @@ type PonyFmTrackAPIError = Infer<typeof ponyFmTrackAPIError>;
 function isPonyFmTrackAPIError(tbd: unknown): tbd is PonyFmTrackAPIError {
 	return is(tbd, ponyFmTrackAPIError);
 }
+
+const metaSource: Readonly<VideoMetaSource> = {
+	platformName: "pony.fm",
+	alternative: null,
+};
 
 /**
  * Gets information about a Pony.fm track.
@@ -101,5 +106,6 @@ export async function getPonyFmTrack(url: URL, signal?: AbortSignal): Promise<Vi
 		url: trackData.url,
 		title: trackData.title,
 		duration: { seconds: Math.floor(Number.parseFloat(trackData.duration)) },
+		metaSource,
 	};
 }

--- a/src/actions/network/getSoundCloudTrack.ts
+++ b/src/actions/network/getSoundCloudTrack.ts
@@ -1,4 +1,4 @@
-import type { VideoDetails } from "../getVideoDetails.js";
+import type { VideoDetails, VideoMetaSource } from "../getVideoDetails.js";
 import type { Song } from "soundcloud-scraper";
 import { Client as SoundCloudClient } from "soundcloud-scraper";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
@@ -6,6 +6,11 @@ import { useLogger } from "../../logger.js";
 import { VideoError } from "../../errors/VideoError.js";
 
 const logger = useLogger();
+
+const metaSource: Readonly<VideoMetaSource> = {
+	platformName: "soundcloud",
+	alternative: null,
+};
 
 /**
  * Gets information about a SoundCloud track.
@@ -49,5 +54,6 @@ export async function getSoundCloudTrack(url: URL, signal?: AbortSignal): Promis
 		url: song.url,
 		title: song.title,
 		duration: { seconds: Math.floor(song.duration / 1000) },
+		metaSource,
 	};
 }

--- a/src/actions/network/getYouTubeVideo.test.ts
+++ b/src/actions/network/getYouTubeVideo.test.ts
@@ -26,6 +26,16 @@ describe("YouTube track details", () => {
 
 	test.each`
 		id               | url
+		${"9Y8ZGLiqXBJ"} | ${"https://youtu.be/9Y8ZGLiqXBJ"}
+		${"9Y8ZGLiqXBK"} | ${"https://www.youtube.com/watch?v=9Y8ZGLiqXBK"}
+	`("throws with nonexistent video ($id)", async ({ url }: { url: string }) => {
+		const error = new UnavailableError(new URL(url));
+		mockGetBasicInfo.mockRejectedValue(error);
+		await expect(() => getYouTubeVideo(new URL(url))).rejects.toThrow(error);
+	});
+
+	test.each`
+		id               | url
 		${"9Y8ZGLiqXba"} | ${"https://youtu.be/9Y8ZGLiqXba"}
 		${"dmneTS-Gows"} | ${"https://www.youtube.com/watch?v=dmneTS-Gows"}
 	`("throws with unavailable video ($id)", async ({ url }: { url: string }) => {

--- a/src/actions/network/getYouTubeVideo.ts
+++ b/src/actions/network/getYouTubeVideo.ts
@@ -1,8 +1,10 @@
 import type { VideoDetails } from "../getVideoDetails.js";
 import type { videoInfo as YTVideoInfo } from "ytdl-core";
-import { array, boolean, is, number, string, type } from "superstruct";
+import { array, boolean, enums, is, literal, number, optional, string, type } from "superstruct";
 import { getBasicInfo, validateURL, getURLVideoID } from "ytdl-core";
+import { getEnv } from "../../helpers/environment.js";
 import { useLogger } from "../../logger.js";
+import { secondsFromIso8601Duration } from "../../helpers/secondsFromIso8601Duration.js";
 import { richErrorMessage } from "../../helpers/richErrorMessage.js";
 import {
 	InvalidYouTubeUrlError,
@@ -34,6 +36,98 @@ export async function getYouTubeVideo(url: URL, signal?: AbortSignal): Promise<V
 	const urlString = url.href;
 	if (!validateURL(urlString)) throw new InvalidYouTubeUrlError(url);
 
+	const YOUTUBE_API_KEY = getEnv("YOUTUBE_API_KEY");
+	if (YOUTUBE_API_KEY) {
+		logger.debug("Found YouTube API key! Using first-party API...");
+		return await getYouTubeVideoViaApi(YOUTUBE_API_KEY, url, signal);
+	}
+
+	// Try alternatives instead
+	logger.debug("No YouTube API key found. Trying alternatives...");
+	return await getYouTubeVideoViaSideChannel(url, signal);
+}
+
+// See https://developers.google.com/youtube/v3/docs/videos/list
+const youtubeDataApiResponse = type({
+	kind: literal("youtube#videoListResponse"),
+	items: array(
+		// See https://developers.google.com/youtube/v3/docs/videos
+		type({
+			id: string(),
+			snippet: type({
+				title: string(),
+				liveBroadcastContent: enums(["live", "none", "upcoming"]),
+			}),
+			contentDetails: type({
+				/** An ISO 8601 duration string */
+				duration: string(),
+				regionRestriction: optional(
+					type({
+						allowed: optional(array(string())),
+						blocked: optional(array(string())),
+					}),
+				),
+			}),
+		}),
+	),
+});
+
+async function getYouTubeVideoViaApi(
+	key: string,
+	url: URL,
+	signal?: AbortSignal,
+): Promise<VideoDetails> {
+	const videoId = getURLVideoID(url.href);
+	const api = new URL("https://www.googleapis.com/youtube/v3/videos");
+	api.searchParams.set("key", key);
+	api.searchParams.set("id", videoId);
+	api.searchParams.set("maxResults", "1");
+	api.searchParams.set("part", "snippet,contentDetails,liveStreamingDetails,id");
+
+	const response = await fetch(api, { signal });
+	const info: unknown = await response.json();
+	if (!is(info, youtubeDataApiResponse)) {
+		const message = `Malformed response from YouTube Data API with status ${response.status}.`; // TODO: i18n?
+		logger.error(richErrorMessage(message, info));
+		throw new VideoError(message);
+	}
+
+	// Construct a VideoDetails from the response payload
+	const video = info.items[0];
+	if (!video) {
+		throw new UnavailableError(url);
+	}
+
+	if (
+		video.contentDetails.regionRestriction?.blocked?.includes("US") ||
+		video.snippet.liveBroadcastContent === "upcoming"
+	) {
+		throw new UnavailableError(url);
+	}
+
+	let durationSeconds: number;
+	if (video.snippet.liveBroadcastContent === "live") {
+		durationSeconds = Number.POSITIVE_INFINITY;
+	} else {
+		durationSeconds = secondsFromIso8601Duration(video.contentDetails.duration);
+	}
+
+	return {
+		url: `https://www.youtube.com/watch?v=${videoId}`,
+		title: video.snippet.title,
+		duration: {
+			seconds: durationSeconds,
+		},
+	};
+}
+
+async function getYouTubeVideoViaSideChannel(
+	url: URL,
+	signal?: AbortSignal,
+): Promise<VideoDetails> {
+	const urlString = url.href;
+	if (!validateURL(urlString)) throw new InvalidYouTubeUrlError(url);
+
 	let info: YouTubeVideoInfo;
 	try {
 		info = await getBasicInfo(urlString, { requestOptions: { signal } });
@@ -42,7 +136,7 @@ export async function getYouTubeVideo(url: URL, signal?: AbortSignal): Promise<V
 		logger.debug("Trying Invidius proxy instead...");
 
 		// Try an Invidius instance instead
-		// TODO: Report upstream that a proxy was used, and show that in `/test` output
+		// TODO: Report upstream which proxy was used, and show that in `/test` output
 		try {
 			info = await invidius(url, signal);
 		} catch (error) {

--- a/src/actions/network/getYouTubeVideo.ts
+++ b/src/actions/network/getYouTubeVideo.ts
@@ -72,6 +72,8 @@ const youtubeDataApiResponse = type({
 	),
 });
 
+// TODO: Organize this better!!
+
 async function getYouTubeVideoViaApi(
 	key: string,
 	url: URL,
@@ -82,7 +84,7 @@ async function getYouTubeVideoViaApi(
 	api.searchParams.set("key", key);
 	api.searchParams.set("id", videoId);
 	api.searchParams.set("maxResults", "1");
-	api.searchParams.set("part", "snippet,contentDetails,liveStreamingDetails,id");
+	api.searchParams.set("part", "snippet,contentDetails,id");
 
 	const response = await fetch(api, { signal });
 	const info: unknown = await response.json();
@@ -113,7 +115,7 @@ async function getYouTubeVideoViaApi(
 	}
 
 	return {
-		url: `https://www.youtube.com/watch?v=${videoId}`,
+		url: `https://www.youtube.com/watch?v=${video.id}`, // TODO: Is there a way to get a canonical URL from YouTube directly?
 		title: video.snippet.title,
 		duration: {
 			seconds: durationSeconds,

--- a/src/actions/network/getYouTubeVideo.ts
+++ b/src/actions/network/getYouTubeVideo.ts
@@ -118,6 +118,10 @@ async function getYouTubeVideoViaApi(
 		duration: {
 			seconds: durationSeconds,
 		},
+		metaSource: {
+			platformName: "youtube",
+			alternative: null,
+		},
 	};
 }
 
@@ -129,6 +133,7 @@ async function getYouTubeVideoViaSideChannel(
 	if (!validateURL(urlString)) throw new InvalidYouTubeUrlError(url);
 
 	let info: YouTubeVideoInfo;
+	let usedInvidius = false;
 	try {
 		info = await getBasicInfo(urlString, { requestOptions: { signal } });
 	} catch (error) {
@@ -138,6 +143,7 @@ async function getYouTubeVideoViaSideChannel(
 		// Try an Invidius instance instead
 		// TODO: Report upstream which proxy was used, and show that in `/test` output
 		try {
+			usedInvidius = true;
 			info = await invidius(url, signal);
 		} catch (error) {
 			if (error instanceof VideoError) {
@@ -162,6 +168,10 @@ async function getYouTubeVideoViaSideChannel(
 		url: info.videoDetails.video_url,
 		title: info.videoDetails.title,
 		duration: { seconds },
+		metaSource: {
+			platformName: "youtube",
+			alternative: usedInvidius ? "iv.ggtyler.dev" : "ytdl",
+		},
 	};
 }
 

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,2 +1,4 @@
-export const MILLISECONDS_IN_SECOND = 1000;
+export const SECONDS_IN_HOUR = 3_600;
 export const SECONDS_IN_MINUTE = 60;
+
+export const MILLISECONDS_IN_SECOND = 1_000;

--- a/src/helpers/environment.ts
+++ b/src/helpers/environment.ts
@@ -18,7 +18,8 @@ export type EnvKey =
 	| "NODE_ENV"
 	| "QUEUE_ADMIN_ROLE_ID"
 	| "QUEUE_CHANNEL_ID"
-	| "QUEUE_CREATOR_ROLE_ID";
+	| "QUEUE_CREATOR_ROLE_ID"
+	| "YOUTUBE_API_KEY";
 
 /**
  * Fetches the value of an environment variable key.

--- a/src/helpers/secondsFromIso8601Duration.test.ts
+++ b/src/helpers/secondsFromIso8601Duration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { secondsFromIso8601Duration } from "./secondsFromIso8601Duration.js";
+import { SECONDS_IN_HOUR } from "../constants/time.js";
+
+describe("Converting ISO 8601 duration strings into number of seconds", () => {
+	test.each([
+		["PT0S", 0],
+		["PT00S", 0],
+		["PT0M00S", 0],
+		["PT00M00S", 0],
+		["PT5S", 5],
+		["PT10S", 10],
+		["PT90S", 90],
+		["PT1M30S", 90],
+		["PT01M30S", 90],
+		["PT1H1M30S", SECONDS_IN_HOUR + 90],
+	])("converts '%s' to %ds", (duration, seconds) => {
+		expect(secondsFromIso8601Duration(duration)).toBe(seconds);
+	});
+
+	test.each([
+		// Bandcamp's examples
+		"P00H03M53S", // https://poniesatdawn.bandcamp.com/track/let-the-magic-fill-your-soul
+		"P00H04M37S", // https://forestrainmedia.com/track/bad-wolf
+		"P00H02M50S", // https://lehtmojoe.bandcamp.com/track/were-not-going-home-dallas-stars-2020
+	])("throws on non-standard string '%s'", duration => {
+		expect(() => secondsFromIso8601Duration(duration)).toThrow(RangeError);
+	});
+});

--- a/src/helpers/secondsFromIso8601Duration.ts
+++ b/src/helpers/secondsFromIso8601Duration.ts
@@ -1,0 +1,11 @@
+import { Temporal } from "temporal-polyfill";
+
+/**
+ * Returns the number of seconds represented by the given string,
+ * if the string is in ISO 8601 duration format.
+ */
+export function secondsFromIso8601Duration(durationString: string): number {
+	const duration = Temporal.Duration.from(durationString);
+	// const now = Temporal.Now.plainDateTime("gregory"); // Needed for durations that use larger units than Hour
+	return duration.total({ unit: "seconds" /* relativeTo: now */ });
+}


### PR DESCRIPTION
Worked out a more reliable way to get YouTube metadata! Now, if an API key is provided, we call YouTube's first-party data API instead of going through `ytdl-core` or an Invidius proxy, since these are prone to break at any time at YouTube's whims.

I wish I didn't need a Google account to use this feature reliably, but this will work well enough for now. Maybe one day I'll have worked out a reliable way to proxy YouTube's API again.